### PR TITLE
chore: support laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^8.4",
         "filament/filament": "^5.0",
-        "illuminate/contracts": "^12.0",
+        "illuminate/contracts": "^12.0|^13.0",
         "ralphjsmit/laravel-filament-seo": "^2.0",
         "ralphjsmit/laravel-seo": "^1.7",
         "spatie/laravel-markdown": "^2.7",


### PR DESCRIPTION
## Summary

Widens `illuminate/contracts` to include `^13.0` so the package installs cleanly on Laravel 13. The package itself uses no Laravel-13-breaking APIs — only the constraint needed updating.

## Changes

`composer.json`:
```diff
- "illuminate/contracts": "^12.0",
+ "illuminate/contracts": "^12.0|^13.0",
```

## Compatibility

Existing Laravel 12 users are unaffected; new Laravel 13 users can now install without dependency resolution failures.