### PR TITLE
docs(tags): fix nav icon (i-lucide-hashtag → i-lucide-hash)

### DIFF
--- a/docs/content/2.essentials/5.tags.md
+++ b/docs/content/2.essentials/5.tags.md
@@ -2,7 +2,7 @@
 title: Tags Taxonomy
 description: Opt-in many-to-many tags taxonomy with admin UI and public archive.
 navigation:
-  icon: i-lucide-hashtag
+  icon: i-lucide-hash
 ---
 
 Tags are an **opt-in** feature — the schema ships with every install but the admin UI, form field, and public archive only appear when `features.tags` is on.


### PR DESCRIPTION
Lucide names the # icon `hash`, not `hashtag`. The tags doc page used the wrong name in its nav frontmatter so the icon failed to render. The homepage and tag-related Filament resource icons (`heroicon-o-hashtag`, which is valid in Heroicons) are unaffected.