### PR TITLE
docs: polish homepage — clearer hero, code preview, fewer cards

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,15 +1,15 @@
 ---
 seo:
-  title: Filament Blog - Headless Blog Package
-  description: Headless-by-default blog package for Filament. Opt-in public routes, tags taxonomy, MediaLibrary integration, MCP tools, and SEO components — your app stays in control.
+  title: Filament Blog — Headless blog package for Filament
+  description: Drop a blog into any Filament 5 app. Ships admin, SEO, MCP tools, and Blade components — bring your own routes or opt into the built-in ones with a config flag.
 ---
 
 ::u-page-hero
 #title
-Filament Blog
+A blog you can drop into any Filament app
 
 #description
-Headless-by-default blog for Filament 5 — opt into public routes, RSS feed, tags taxonomy, and MediaLibrary integration with config flags. Your app stays in control.
+Ships the admin, SEO components, MCP tools, and Blade components. Bring your own routes for full control — or flip a flag and get `/blog` out of the box.
 
 #links
   :::u-button
@@ -30,13 +30,16 @@ Headless-by-default blog for Filament 5 — opt into public routes, RSS feed, ta
   to: https://github.com/ManukMinasyan/filament-blog
   variant: outline
   ---
-  GitHub
+  Source on GitHub
   :::
 ::
 
 ::u-page-section
 #title
-Two install modes
+Two ways to install
+
+#description
+Headless by default. Opt in to the built-in routes when you want a working blog without writing controllers.
 
 #features
   :::u-page-feature
@@ -55,16 +58,46 @@ Two install modes
   icon: i-lucide-zap
   ---
   #title
-  Public-routes mode (opt-in)
+  Public-routes mode
   
   #description
-  Flip a config flag — get `/blog`, `/blog/{slug}`, `/blog/category/{slug}`, signed `/blog/preview/{post}`, and optional `/blog/feed`. No Filament panel boot needed.
+  Flip one config flag and get `/blog`, single posts, category and tag archives, signed previews, and an RSS feed. No Filament panel boot needed.
   :::
 ::
 
 ::u-page-section
 #title
-What's in the box
+Five-minute install
+
+#description
+Add the package, run migrations, register the plugin. That's the whole admin path. Public routes are one config flag away.
+
+```bash [Terminal]
+composer require manukminasyan/filament-blog
+php artisan migrate
+```
+
+```php [AppPanelProvider.php]
+use ManukMinasyan\FilamentBlog\FilamentBlogPlugin;
+
+$panel->plugins([
+    FilamentBlogPlugin::make(),
+]);
+```
+
+```php [config/filament-blog.php]
+'features' => [
+    'public_routes' => true,   // /blog, /blog/{slug}, signed /blog/preview/{post}
+    'feed'          => true,   // /blog/feed (RSS 2.0)
+    'tags'          => true,   // TagResource + /blog/tag/{slug}
+    'media_library' => false,  // SpatieMediaLibraryFileUpload (optional)
+],
+```
+::
+
+::u-page-section
+#title
+What's included
 
 #features
   :::u-page-feature
@@ -72,10 +105,10 @@ What's in the box
   icon: i-lucide-layout-dashboard
   ---
   #title
-  Filament Admin Panel
+  Filament admin
   
   #description
-  PostResource and CategoryResource with markdown editor, draft/scheduled UX, SEO fields, featured images, and bulk publish/unpublish/schedule actions.
+  Posts, categories, tags. Markdown editor, draft and scheduled UX, SEO fields, bulk publish actions.
   :::
 
   :::u-page-feature
@@ -83,10 +116,10 @@ What's in the box
   icon: i-lucide-search
   ---
   #title
-  SEO Components
+  SEO baked in
   
   #description
-  Meta tags, Open Graph, Twitter Cards, JSON-LD `BlogPosting`, RSS feed, canonical URLs — all publishable Blade components.
+  Meta tags, Open Graph, Twitter Cards, JSON-LD `BlogPosting`, RSS feed, and a sitemap helper — all publishable.
   :::
 
   :::u-page-feature
@@ -94,10 +127,10 @@ What's in the box
   icon: i-lucide-bot
   ---
   #title
-  13 MCP Tools
+  MCP tools for AI
   
   #description
-  Full CRUD for posts and categories via Model Context Protocol with Sanctum ability gating and markdown sanitization (HTML stripped, unsafe links blocked).
+  13 Model Context Protocol tools so AI agents can write and publish posts. Sanctum-gated and markdown-sanitized.
   :::
 
   :::u-page-feature
@@ -105,10 +138,10 @@ What's in the box
   icon: i-lucide-hash
   ---
   #title
-  Tags taxonomy (opt-in)
+  Tags taxonomy
   
   #description
-  Many-to-many `blog_post_tag` table, `TagResource` admin UI, public archive at `/blog/tag/{slug}` — all behind a single config flag.
+  Many-to-many tags with admin UI and a public archive at `/blog/tag/{slug}`. All behind one config flag.
   :::
 
   :::u-page-feature
@@ -116,10 +149,10 @@ What's in the box
   icon: i-lucide-image
   ---
   #title
-  MediaLibrary integration (opt-in)
+  MediaLibrary ready
   
   #description
-  When the flag is on and `spatie/laravel-medialibrary` is installed, featured-image uploads use `SpatieMediaLibraryFileUpload`. Falls back gracefully if the package isn't installed.
+  Featured-image uploads switch to `SpatieMediaLibraryFileUpload` when you install the package and flip the flag.
   :::
 
   :::u-page-feature
@@ -127,31 +160,22 @@ What's in the box
   icon: i-lucide-paintbrush
   ---
   #title
-  Publishable UI Components
+  Tailwind components
   
   #description
-  Post-card, post-header, post-body, related-posts, and more — Tailwind + dark mode out of the box. Publish to fully customize.
+  Post card, header, body, related posts, preview banner. Dark mode out of the box. Publish and customize.
   :::
+::
 
-  :::u-page-feature
-  ---
-  icon: i-lucide-map
-  ---
-  #title
-  Sitemap Generator
-  
-  #description
-  Route-aware sitemap helper that automatically adds blog index, categories, tags, and individual posts.
-  :::
+::u-page-section
+#title
+Built for teams replacing internal blogs
 
-  :::u-page-feature
-  ---
-  icon: i-lucide-clock
-  ---
-  #title
-  Reading time + related posts
-  
-  #description
-  `Post::readingTime()` and `Post::relatedPosts()` helpers ship with the model. No extra queries to wire.
-  :::
+#description
+The schema and admin shape match what Tapix and FilaForms ship internally — so swapping in is a `composer remove` away. No data migration, no template rewrites unless you want them.
+
+```bash [Terminal]
+composer remove tapix/blog        # or filaforms/blog
+composer require manukminasyan/filament-blog
+```
 ::


### PR DESCRIPTION
## Summary

The current homepage at https://manukminasyan.github.io/filament-blog/ has two main weaknesses:

1. **Sparse + visually thin.** Hero is just text; no code preview anywhere. Plenty of empty space.
2. **Feature-card section overloads.** Eight cards in 3 columns with uneven description lengths — looks busy. Sitemap and Reading-time cards don't pull their weight.

This PR rebalances the page.

## Changes

| Section | Before → After |
|---|---|
| Hero copy | Feature-listy ("opt into public routes, RSS feed, tags taxonomy, and MediaLibrary integration with config flags") → Value-driven ("A blog you can drop into any Filament app") |
| Mode cards | Same 2 cards; tightened copy on public-routes (drops the `/blog/{slug}` path-list, linked page covers it) |
| **NEW: Five-minute install** | New section with 3 code blocks (composer + migrate, plugin registration, feature flags). Gives visitors an immediate read on the install path |
| What's included | Reduced 8 → 6 cards. Dropped Sitemap (folded into SEO card), Reading time (helper feature, weak in card form). Card descriptions normalized to ~2 short lines each |
| **NEW: Built for teams replacing internal blogs** | Bottom section with the Tapix/FilaForms swap recipe — speaks to the package's actual primary audience |

## Visual impact

- Card heights become consistent (no more uneven jumps)
- Adds two visual breaks (the install code section + the migration code section) — page reads less as a wall of feature cards
- Total content roughly the same length, just better distributed

## Out of scope

- No image / illustration / hero graphic — the package is text-and-code focused; staying consistent with that
- No version badge / release callout — the GitHub button covers this for now; can be added in a follow-up if there's demand