### PR TITLE
docs: tighten homepage hero headline

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -6,7 +6,7 @@ seo:
 
 ::u-page-hero
 #title
-A blog you can drop into any Filament app
+A drop-in blog for Filament
 
 #description
 Ships the admin, SEO components, MCP tools, and Blade components. Bring your own routes for full control — or flip a flag and get `/blog` out of the box.


### PR DESCRIPTION
Previous headline 'A blog you can drop into any Filament app' wrapped to two lines on lg with 'app' orphaned alone. Replace with 'A drop-in blog for Filament' — same meaning, fits one line, sharper.