### PR TITLE
chore: widen spatie/laravel-sitemap to support v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ralphjsmit/laravel-seo": "^1.7",
         "spatie/laravel-markdown": "^2.7",
         "spatie/laravel-package-tools": "^1.15",
-        "spatie/laravel-sitemap": "^7.0",
+        "spatie/laravel-sitemap": "^7.0 || ^8.0",
         "spatie/laravel-sluggable": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
Allows installation alongside apps that have already moved to spatie/laravel-sitemap v8. The package code does not use any v7-only APIs.