### PR TITLE
fix(docs): repoint GitHub Pages build to relaticle/ink

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -58,8 +58,8 @@ jobs:
         working-directory: ./docs
         run: npm run generate
         env:
-          NUXT_APP_BASE_URL: /filament-blog/
-          NUXT_SITE_URL: https://manukminasyan.github.io
+          NUXT_APP_BASE_URL: /ink/
+          NUXT_SITE_URL: https://relaticle.github.io
 
       - name: Deploy to gh-pages
         run: |

--- a/docs/app.config.ts
+++ b/docs/app.config.ts
@@ -1,10 +1,10 @@
 export default defineAppConfig({
     docus: {
-        title: 'Filament Blog',
+        title: 'Ink',
         description: 'Headless blog package for Filament with SEO, MCP tools, and publishable components.',
     },
     seo: {
-        title: 'Filament Blog',
+        title: 'Ink',
         description: 'Headless blog package for Filament with SEO, MCP tools, and publishable components.',
     },
     github: {

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install Filament Blog in your Laravel application.
+description: Install Ink in your Laravel application.
 navigation:
   icon: i-lucide-download
 ---

--- a/docs/content/2.essentials/4.configuration.md
+++ b/docs/content/2.essentials/4.configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Full configuration reference for Filament Blog.
+description: Full configuration reference for Ink.
 navigation:
   icon: i-lucide-settings
 ---

--- a/docs/content/4.community/1.contributing.md
+++ b/docs/content/4.community/1.contributing.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-description: How to contribute to Filament Blog.
+description: How to contribute to Ink.
 navigation:
   icon: i-lucide-git-pull-request
 ---

--- a/docs/content/4.community/2.license.md
+++ b/docs/content/4.community/2.license.md
@@ -5,4 +5,4 @@ navigation:
   icon: i-lucide-scale
 ---
 
-Filament Blog is open-sourced software licensed under the [MIT License](https://opensource.org/licenses/MIT).
+Ink is open-sourced software licensed under the [MIT License](https://opensource.org/licenses/MIT).

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,6 +1,6 @@
 ---
 seo:
-  title: Filament Blog — Headless blog package for Filament
+  title: Ink — Headless blog package for Filament
   description: Drop a blog into any Filament 5 app. Ships admin, SEO, MCP tools, and Blade components — bring your own routes or opt into the built-in ones with a config flag.
 ---
 

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -5,7 +5,7 @@ export default defineNuxtConfig({
     modules: ['@nuxt/image'],
     devtools: { enabled: true },
     site: {
-        name: 'Filament Blog',
+        name: 'Ink',
     },
     appConfig: {
         docus: {


### PR DESCRIPTION
## Why

The deployed docs site at https://relaticle.github.io/ink/ is currently broken — every CSS and JS file 404s because the rendered HTML hardcodes asset paths to \`/filament-blog/*\` (the old repo name).

Verify:
\`\`\`bash
curl -s https://relaticle.github.io/ink/ | grep -oE '/filament-blog/' | head -3
# /filament-blog/
# /filament-blog/
# /filament-blog/
\`\`\`

## Root cause

\`.github/workflows/deploy-docs.yml\` hardcoded \`NUXT_APP_BASE_URL: /filament-blog/\` and \`NUXT_SITE_URL: https://manukminasyan.github.io\`. GitHub auto-redirects the *repo URL* on transfer, but the gh-pages base path is the new repo name (\`ink\`), so previously-built assets reference the wrong path.

This commit was originally pushed to PR #10 as a follow-up, but the squash-merge happened before it landed.

## Fix

- \`deploy-docs.yml\`: \`NUXT_APP_BASE_URL: /filament-blog/\` → \`/ink/\`
- \`deploy-docs.yml\`: \`NUXT_SITE_URL: https://manukminasyan.github.io\` → \`https://relaticle.github.io\`
- \`docs/nuxt.config.ts\`: \`site.name: 'Filament Blog'\` → \`'Ink'\`
- Remaining \"Filament Blog\" brand strings in \`docs/content/*\` and \`docs/app.config.ts\`

8 files changed, 10/-10.

## Test plan

- [ ] CI green
- [ ] After merge, deploy-docs workflow rebuilds gh-pages with \`/ink/\` paths
- [ ] \`curl -s https://relaticle.github.io/ink/ | grep -oE '/filament-blog/'\` returns nothing
- [ ] Site loads with styles in browser