### PR TITLE
v2.1.0: listing SEO bug fixes, schema completion, search, pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.0] - Unreleased
+
+### Added
+- `Relaticle\Ink\Support\BlogListingSeo` helper for building per-page `SEOData` for listings. Headless consumers can call `BlogListingSeo::forIndex/forCategory/forTag` from their own controllers.
+- Auto-emit `FAQPage` JSON-LD on post pages when content contains an `## FAQ` H2 followed by `### Question?` / answer-paragraph pairs. Controlled by `schema.faq_auto` config (default `true`).
+- Auto-emit `HowTo` JSON-LD on post pages when content contains a `## Steps` H2 followed by `### Step Name` / paragraph pairs. Opt-in via `schema.howto_auto` config (default `false`).
+- `Relaticle\Ink\Support\SchemaExtractor` helper for FAQ + HowTo HTML parsing.
+- Auto-emit `Blog` and `CollectionPage` JSON-LD on listing routes (`blog.index` emits both; `blog.category` and `blog.tag` emit `CollectionPage`).
+- Numbered, aria-labeled pagination view at `ink::pagination.blog`. Listing pages (index/category/tag) use it by default. Publish via `php artisan vendor:publish --tag=ink-views` to customize.
+- `wire:navigate` on the `<x-ink::post-card>` post-link and pagination links for SPA-feel navigation in Livewire 4 hosts. No-op when Livewire is not present.
+- `Post::search($term)` query scope. Defaults to a portable LIKE search across title/excerpt/content. Override via `search.callback` config for Postgres FTS, MySQL FULLTEXT, Scout, etc.
+- The shipped `/blog` route now honors `?q=` for search. The existing `BlogListingSeo::forIndex(searchQuery:)` call ensures `noindex,follow` is set on search result URLs.
+- `BlogSearch` Livewire component (`<livewire:blog::search />`) with URL-synced `?q=` query, 400ms debounce, and empty state. Theme-agnostic — publish the view at `resources/views/vendor/ink/livewire/blog-search.blade.php` to restyle.
+
+### Fixed
+- `BlogSitemapGenerator` now includes `/blog/tag/{slug}` URLs when the tags feature is enabled and the tag has published posts.
+- Listing routes (`/blog`, `/blog/category/{slug}`, `/blog/tag/{slug}`) now emit per-page canonical URLs and page-aware titles. Previously every paginated page canonicalized to page 1, causing Google to treat pages 2+ as duplicate content.
+- Shipped `show` and `preview` routes now call `seo()->for($post)` so post-attached SEO (BlogPosting + BreadcrumbList + FAQPage JSON-LD) actually renders in public-routes mode. Previously the schema only worked for consumers who overrode the controller.
+
 ## [2.0.0] - Unreleased
 
 ### Changed (BREAKING)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Filament-native content publishing for blog, docs, and AI-citable articles. Ship
 ## Features
 
 - **Filament Admin** — PostResource and CategoryResource with markdown editor, draft/published/scheduled UX, SEO fields, featured images, and bulk publish/unpublish/schedule actions
-- **SEO Components** — Meta tags, Open Graph, Twitter Cards, JSON-LD structured data, RSS feed, canonical URLs
+- **SEO Components** — Meta tags, Open Graph, Twitter Cards, RSS feed, per-page canonicals on paginated listings
+- **JSON-LD Schema** — `BlogPosting` + `BreadcrumbList` on post pages, `FAQPage` and `HowTo` auto-detected from content (opt-in), `Blog` + `CollectionPage` on listings
+- **Search** — Portable `Post::search()` scope (LIKE by default, override for FTS / Scout), drop-in `BlogSearch` Livewire component with `?q=` URL sync
 - **13 MCP Tools** — Full CRUD for posts and categories via Model Context Protocol, with markdown sanitization (HTML stripped, unsafe links blocked)
 - **Publishable UI Components** — Post card, header, body, related posts, category badge, preview banner — all with dark mode
 - **Two install modes**

--- a/config/ink.php
+++ b/config/ink.php
@@ -32,6 +32,15 @@ return [
         'logo' => null,
     ],
 
+    'schema' => [
+        'faq_auto' => true,
+        'howto_auto' => false,
+    ],
+
+    'search' => [
+        'callback' => null,
+    ],
+
     'tables' => [
         'posts' => 'blog_posts',
         'categories' => 'blog_categories',

--- a/docs/content/2.essentials/1.blade-components.md
+++ b/docs/content/2.essentials/1.blade-components.md
@@ -100,3 +100,17 @@ Sticky amber banner for draft previews. Pushes `noindex` meta tag.
 ```blade
 <x-ink::preview-banner :post="$post" :editUrl="$editUrl" />
 ```
+
+## Pagination
+
+The package ships a numbered, aria-labeled pagination view used by the index/category/tag pages. To use it in your own views:
+
+```blade
+{{ $posts->links('ink::pagination.blog') }}
+```
+
+The view emits `aria-label="Blog pagination"` on the nav, `aria-current="page"` on the active page, and `wire:navigate` on every link.
+
+## Search (Livewire)
+
+Drop `<livewire:blog::search />` anywhere. It reads `?q=` from the URL, debounces 400ms, and renders up to 20 matching posts. Empty queries show no results until the user types.

--- a/docs/content/2.essentials/4.configuration.md
+++ b/docs/content/2.essentials/4.configuration.md
@@ -84,6 +84,31 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Schema auto-emission
+    |--------------------------------------------------------------------------
+    | Detect FAQ and HowTo sections in post content and emit JSON-LD schema
+    | automatically. FAQ detection looks for an `## FAQ` H2 followed by H3
+    | question / paragraph answer pairs. HowTo detection looks for a `## Steps`
+    | H2 followed by H3 step headings.
+    */
+    'schema' => [
+        'faq_auto' => true,
+        'howto_auto' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Search
+    |--------------------------------------------------------------------------
+    | Defaults to a portable LIKE search across title/excerpt/content.
+    | Override `callback` to use Postgres FTS, MySQL FULLTEXT, Scout, etc.
+    */
+    'search' => [
+        'callback' => null,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | RSS feed metadata
     |--------------------------------------------------------------------------
     */

--- a/docs/content/2.essentials/7.search.md
+++ b/docs/content/2.essentials/7.search.md
@@ -1,0 +1,55 @@
+---
+title: Search
+description: Portable search across blog posts with a config-driven backend hook.
+navigation:
+  icon: i-lucide-search
+---
+
+The package ships a `Post::search($term)` query scope and a `BlogSearch` Livewire component.
+
+## Default behavior
+
+`Post::search($term)` does a `LIKE` search across `title`, `excerpt`, and `content`. Works on every database driver out of the box.
+
+```php
+$posts = Post::query()
+    ->published()
+    ->search($request->query('q', ''))
+    ->latest('published_at')
+    ->paginate(12);
+```
+
+Empty / whitespace-only terms are no-ops — the scope leaves the query unchanged. LIKE wildcards in the term are escaped.
+
+## Override the backend
+
+Set `search.callback` in `config/ink.php` to use Postgres FTS, MySQL FULLTEXT, Scout, Meilisearch, or anything else:
+
+```php
+'search' => [
+    'callback' => function (\Illuminate\Database\Eloquent\Builder $query, string $term): void {
+        $query->whereRaw(
+            "to_tsvector('english', title || ' ' || excerpt || ' ' || content) @@ plainto_tsquery('english', ?)",
+            [$term]
+        );
+    },
+],
+```
+
+Whatever the callback applies becomes the search strategy. Empty terms still short-circuit before the callback fires.
+
+## Livewire component
+
+Use `<livewire:blog::search />` anywhere. It reads `?q=` from the URL, debounces 400ms, and renders up to 20 matches with an empty state.
+
+To restyle, publish the view:
+
+```bash
+php artisan vendor:publish --tag=ink-views
+```
+
+Then edit `resources/views/vendor/ink/livewire/blog-search.blade.php`.
+
+## SEO
+
+When the shipped `/blog` route handles `?q=`, the package emits `<meta name="robots" content="noindex,follow">` on the search result page. Search queries should not be indexed as separate URLs.

--- a/docs/content/2.essentials/8.schema.md
+++ b/docs/content/2.essentials/8.schema.md
@@ -1,0 +1,64 @@
+---
+title: Schema
+description: Automatic JSON-LD schema emission for posts and listings.
+navigation:
+  icon: i-lucide-code-2
+---
+
+The package emits JSON-LD schema automatically for blog content. Each schema type can be toggled in `config/ink.php`.
+
+## What's emitted by default
+
+| Schema | Where | Toggle |
+|---|---|---|
+| `BlogPosting` | Post pages | Always on (via `Post::getDynamicSEOData()`) |
+| `BreadcrumbList` | Post pages | Always on |
+| `FAQPage` | Post pages with `## FAQ` section | `schema.faq_auto` (default `true`) |
+| `HowTo` | Post pages with `## Steps` section | `schema.howto_auto` (default `false`) |
+| `Blog` | `/blog` index | Always when public-routes mode is on |
+| `CollectionPage` | `/blog`, `/blog/category/{slug}`, `/blog/tag/{slug}` | Always when public-routes mode is on |
+
+## FAQPage conventions
+
+To trigger FAQPage emission, include a `## FAQ` heading followed by `### Question?` and a paragraph answer:
+
+```markdown
+## FAQ
+
+### Does the package auto-emit schema?
+Yes — FAQ schema is on by default.
+
+### Can I turn it off?
+Set `schema.faq_auto` to `false`.
+```
+
+## HowTo conventions
+
+To trigger HowTo emission, opt in via `schema.howto_auto = true` and write a `## Steps` section with `### Step Name` headings:
+
+```markdown
+## Steps
+
+### Install the package
+Run `composer require relaticle/ink`.
+
+### Publish the config
+Run `php artisan vendor:publish --tag=ink-config`.
+```
+
+Each `### heading` becomes a `HowToStep` with auto-incremented `position`.
+
+## Disabling auto-detection
+
+```php
+'schema' => [
+    'faq_auto' => false,
+    'howto_auto' => false,
+],
+```
+
+The `BlogPosting` + `BreadcrumbList` schemas remain on regardless — they're considered baseline for any blog.
+
+## Validate your schema
+
+After publishing, paste a post URL into [Google Rich Results Test](https://search.google.com/test/rich-results) or the [Schema.org Validator](https://validator.schema.org/) to confirm zero errors.

--- a/docs/content/2.essentials/9.listing-seo.md
+++ b/docs/content/2.essentials/9.listing-seo.md
@@ -1,0 +1,48 @@
+---
+title: Listing SEO
+description: Per-page canonicals, titles, and metadata for listing routes.
+navigation:
+  icon: i-lucide-list
+---
+
+The package's listing routes (`/blog`, `/blog/category/{slug}`, `/blog/tag/{slug}`) emit per-page canonical URLs, titles, and metadata via `BlogListingSeo`.
+
+## Behavior
+
+| Route | Page 1 canonical | Page N canonical |
+|---|---|---|
+| `/blog` | `/blog` | `/blog?page=N` |
+| `/blog?q=term` | `/blog` | `noindex,follow` |
+| `/blog/category/guides` | `/blog/category/guides` | `/blog/category/guides?page=N` |
+| `/blog/tag/filament` | `/blog/tag/filament` | `/blog/tag/filament?page=N` |
+
+Titles include `— Page N` from page 2 onward.
+
+## Headless consumers
+
+If you write your own controllers in headless mode, call the helper directly:
+
+```php
+use Relaticle\Ink\Support\BlogListingSeo;
+
+public function index(Request $request)
+{
+    $page = (int) $request->query('page', 1);
+    seo()->for(BlogListingSeo::forIndex(page: $page, searchQuery: $request->query('q')));
+
+    return view('blog.index', [...]);
+}
+```
+
+Available factories:
+- `BlogListingSeo::forIndex(int $page = 1, ?string $searchQuery = null): SEOData`
+- `BlogListingSeo::forCategory(Category $category, int $page = 1): SEOData`
+- `BlogListingSeo::forTag(Tag $tag, int $page = 1): SEOData`
+
+## Pagination
+
+The package ships a numbered, aria-labeled pagination view at `ink::pagination.blog`. Listing pages use it by default. Publish to customize:
+
+```bash
+php artisan vendor:publish --tag=ink-views
+```

--- a/resources/views/components/post-card.blade.php
+++ b/resources/views/components/post-card.blade.php
@@ -1,4 +1,4 @@
-<a href="{{ $post->getUrl() }}" class="group block py-6 -mx-4 px-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-900/50 transition-colors duration-200">
+<a href="{{ $post->getUrl() }}" wire:navigate class="group block py-6 -mx-4 px-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-900/50 transition-colors duration-200">
     <div class="flex items-start justify-between gap-6">
         <div class="min-w-0 flex-1">
             <div class="flex items-center gap-3 mb-2">

--- a/resources/views/livewire/blog-search.blade.php
+++ b/resources/views/livewire/blog-search.blade.php
@@ -1,0 +1,32 @@
+<div>
+    <label for="blog-search" class="sr-only">Search blog posts</label>
+    <input
+        type="search"
+        id="blog-search"
+        wire:model.live.debounce.400ms="query"
+        placeholder="Search posts…"
+        class="w-full rounded-md border border-zinc-200 px-4 py-2 text-sm focus:border-zinc-400 focus:outline-none"
+        aria-label="Search blog posts"
+    />
+
+    @if ($query !== '')
+        <div class="mt-6">
+            @if ($results->isEmpty())
+                <p class="text-sm text-zinc-500">No posts match "{{ $query }}".</p>
+            @else
+                <ul class="space-y-4">
+                    @foreach ($results as $post)
+                        <li>
+                            <a href="{{ $post->getUrl() }}" wire:navigate class="block">
+                                <h3 class="text-base font-medium text-zinc-900">{{ $post->title }}</h3>
+                                @if ($post->excerpt)
+                                    <p class="mt-1 text-sm text-zinc-600">{{ $post->excerpt }}</p>
+                                @endif
+                            </a>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </div>
+    @endif
+</div>

--- a/resources/views/pages/category.blade.php
+++ b/resources/views/pages/category.blade.php
@@ -12,6 +12,6 @@
         @endforelse
     </div>
 
-    <div class="mt-12">{{ $posts->links() }}</div>
+    <div class="mt-12">{{ $posts->links('ink::pagination.blog') }}</div>
 </div>
 @endsection

--- a/resources/views/pages/index.blade.php
+++ b/resources/views/pages/index.blade.php
@@ -13,7 +13,7 @@
     </div>
 
     <div class="mt-12">
-        {{ $posts->links() }}
+        {{ $posts->links('ink::pagination.blog') }}
     </div>
 </div>
 @endsection

--- a/resources/views/pages/tag.blade.php
+++ b/resources/views/pages/tag.blade.php
@@ -12,6 +12,6 @@
         @endforelse
     </div>
 
-    <div class="mt-12">{{ $posts->links() }}</div>
+    <div class="mt-12">{{ $posts->links('ink::pagination.blog') }}</div>
 </div>
 @endsection

--- a/resources/views/pagination/blog.blade.php
+++ b/resources/views/pagination/blog.blade.php
@@ -1,0 +1,53 @@
+@if ($paginator->hasPages())
+    <nav role="navigation" aria-label="Blog pagination" class="flex items-center justify-between mt-10">
+        <div class="flex flex-1 items-center justify-between">
+            @if ($paginator->onFirstPage())
+                <span class="text-sm text-zinc-400" aria-hidden="true">Previous</span>
+            @else
+                <a href="{{ $paginator->previousPageUrl() }}"
+                   rel="prev"
+                   wire:navigate
+                   aria-label="Go to previous page"
+                   class="text-sm text-zinc-600 hover:text-zinc-900">Previous</a>
+            @endif
+
+            <ol class="flex items-center gap-2">
+                @foreach ($elements as $element)
+                    @if (is_string($element))
+                        <li class="text-sm text-zinc-400" aria-hidden="true">{{ $element }}</li>
+                    @endif
+
+                    @if (is_array($element))
+                        @foreach ($element as $page => $url)
+                            <li>
+                                @if ($page == $paginator->currentPage())
+                                    <span aria-current="page"
+                                          class="inline-flex items-center justify-center w-8 h-8 text-sm font-medium text-white bg-zinc-900 rounded">
+                                        {{ $page }}
+                                    </span>
+                                @else
+                                    <a href="{{ $url }}"
+                                       wire:navigate
+                                       aria-label="Go to page {{ $page }}"
+                                       class="inline-flex items-center justify-center w-8 h-8 text-sm text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100 rounded">
+                                        {{ $page }}
+                                    </a>
+                                @endif
+                            </li>
+                        @endforeach
+                    @endif
+                @endforeach
+            </ol>
+
+            @if ($paginator->hasMorePages())
+                <a href="{{ $paginator->nextPageUrl() }}"
+                   rel="next"
+                   wire:navigate
+                   aria-label="Go to next page"
+                   class="text-sm text-zinc-600 hover:text-zinc-900">Next</a>
+            @else
+                <span class="text-sm text-zinc-400" aria-hidden="true">Next</span>
+            @endif
+        </div>
+    </nav>
+@endif

--- a/src/BlogSitemapGenerator.php
+++ b/src/BlogSitemapGenerator.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Route;
 use Relaticle\Ink\Models\Category;
 use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Models\Tag;
 use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\Tags\Url;
 
@@ -49,6 +50,19 @@ class BlogSitemapGenerator
                             ->setLastModificationDate($post->updated_at)
                             ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
                             ->setPriority(0.7)
+                    );
+                });
+        }
+
+        if (Route::has('blog.tag') && config('ink.features.tags', false)) {
+            Tag::query()
+                ->select(['id', 'slug'])
+                ->whereHas('posts', fn (Builder $query) => $query->published())
+                ->each(function (Tag $tag) use ($sitemap): void {
+                    $sitemap->add(
+                        Url::create(route('blog.tag', $tag->slug))
+                            ->setChangeFrequency(Url::CHANGE_FREQUENCY_WEEKLY)
+                            ->setPriority(0.5)
                     );
                 });
         }

--- a/src/Http/Controllers/BlogController.php
+++ b/src/Http/Controllers/BlogController.php
@@ -11,6 +11,7 @@ use Illuminate\Routing\Controller;
 use Relaticle\Ink\Models\Category;
 use Relaticle\Ink\Models\Post;
 use Relaticle\Ink\Models\Tag;
+use Relaticle\Ink\Support\BlogListingSeo;
 
 class BlogController extends Controller
 {
@@ -18,11 +19,25 @@ class BlogController extends Controller
     {
         $perPage = (int) config('ink.per_page', 12);
 
-        $posts = Post::query()
+        $searchQuery = trim((string) $request->query('q', ''));
+
+        $query = Post::query()
             ->with(['category', 'author', 'seo'])
-            ->published()
+            ->published();
+
+        if ($searchQuery !== '') {
+            $query->search($searchQuery);
+        }
+
+        $posts = $query
             ->latest('published_at')
-            ->paginate($perPage);
+            ->paginate($perPage)
+            ->withQueryString();
+
+        seo()->for(BlogListingSeo::forIndex(
+            page: (int) $request->query('page', 1),
+            searchQuery: $request->query('q'),
+        ));
 
         return view('ink::pages.index', [
             'posts' => $posts,
@@ -38,6 +53,8 @@ class BlogController extends Controller
             ->firstOrFail();
 
         $relatedPosts = $post->relatedPosts(limit: 3)->get();
+
+        seo()->for($post);
 
         return view('ink::pages.show', [
             'post' => $post,
@@ -57,6 +74,11 @@ class BlogController extends Controller
             ->latest('published_at')
             ->paginate($perPage);
 
+        seo()->for(BlogListingSeo::forCategory(
+            category: $category,
+            page: (int) request()->query('page', 1),
+        ));
+
         return view('ink::pages.category', [
             'category' => $category,
             'posts' => $posts,
@@ -65,8 +87,12 @@ class BlogController extends Controller
 
     public function preview(Post $post): View
     {
+        $post->loadMissing(['category', 'author', 'seo']);
+
+        seo()->for($post);
+
         return view('ink::pages.preview', [
-            'post' => $post->loadMissing(['category', 'author', 'seo']),
+            'post' => $post,
         ]);
     }
 
@@ -83,6 +109,11 @@ class BlogController extends Controller
             ->published()
             ->latest('published_at')
             ->paginate($perPage);
+
+        seo()->for(BlogListingSeo::forTag(
+            tag: $tag,
+            page: (int) request()->query('page', 1),
+        ));
 
         return view('ink::pages.tag', [
             'tag' => $tag,

--- a/src/InkServiceProvider.php
+++ b/src/InkServiceProvider.php
@@ -5,8 +5,17 @@ declare(strict_types=1);
 namespace Relaticle\Ink;
 
 use Illuminate\Support\Facades\Blade;
+use Livewire\Livewire;
+use RalphJSmit\Laravel\SEO\Facades\SEOManager;
+use RalphJSmit\Laravel\SEO\Schema\CustomSchema;
+use RalphJSmit\Laravel\SEO\TagCollection;
+use RalphJSmit\Laravel\SEO\TagManager;
+use Relaticle\Ink\Livewire\BlogSearch;
+use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Support\SchemaExtractor;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Throwable;
 
 class InkServiceProvider extends PackageServiceProvider
 {
@@ -23,6 +32,13 @@ class InkServiceProvider extends PackageServiceProvider
             ->hasViews(static::$viewNamespace);
     }
 
+    public function packageRegistered(): void
+    {
+        // TagManager must be a singleton so seo()->for() called in the
+        // BlogController persists to the {!! seo() !!} call in the layout.
+        $this->app->singleton(TagManager::class);
+    }
+
     public function packageBooted(): void
     {
         Blade::componentNamespace('Relaticle\\Ink\\Components', 'ink');
@@ -30,5 +46,125 @@ class InkServiceProvider extends PackageServiceProvider
         if (config('ink.features.public_routes')) {
             $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
         }
+
+        $this->registerHowToSchemaTransformer();
+        $this->registerListingSchemaTransformer();
+
+        if (class_exists(Livewire::class)) {
+            Livewire::component('blog::search', BlogSearch::class);
+
+            Livewire::resolveMissingComponent(function (string $name): ?string {
+                if ($name === 'blog::search') {
+                    return BlogSearch::class;
+                }
+
+                return null;
+            });
+        }
+    }
+
+    private function registerHowToSchemaTransformer(): void
+    {
+        SEOManager::tagTransformer(function (TagCollection $tags): TagCollection {
+            if (! config('ink.schema.howto_auto', false)) {
+                return $tags;
+            }
+
+            try {
+                $route = request()->route();
+                $param = $route?->parameter('post');
+
+                $post = $param instanceof Post
+                    ? $param
+                    : (is_string($param)
+                        ? Post::query()->published()->where('slug', $param)->first()
+                        : null);
+
+                if (! $post instanceof Post && ($slug = $route?->parameter('slug')) !== null) {
+                    $post = Post::query()->published()->where('slug', $slug)->first();
+                }
+
+                if (! $post instanceof Post) {
+                    return $tags;
+                }
+
+                $steps = SchemaExtractor::extractHowToSteps($post->renderedContent());
+
+                if ($steps === []) {
+                    return $tags;
+                }
+
+                $tags->push(new CustomSchema([
+                    '@context' => 'https://schema.org',
+                    '@type' => 'HowTo',
+                    'name' => $post->title,
+                    'step' => $steps,
+                ]));
+
+                return $tags;
+            } catch (Throwable) {
+                return $tags;
+            }
+        });
+    }
+
+    private function registerListingSchemaTransformer(): void
+    {
+        SEOManager::tagTransformer(function (TagCollection $tags): TagCollection {
+            try {
+                $route = request()->route();
+                $routeName = $route?->getName();
+
+                $isIndex = $routeName === 'blog.index';
+                $isCategory = $routeName === 'blog.category';
+                $isTag = $routeName === 'blog.tag';
+
+                if (! ($isIndex || $isCategory || $isTag)) {
+                    return $tags;
+                }
+
+                $publisher = config('ink.publisher');
+                $publisherEntity = $publisher && ! empty($publisher['name']) ? [
+                    '@type' => 'Organization',
+                    'name' => $publisher['name'],
+                    'url' => $publisher['url'] ?? null,
+                ] : null;
+
+                $collectionName = match (true) {
+                    $isCategory => (string) ($route?->parameter('slug') ?? 'Category'),
+                    $isTag => (string) ($route?->parameter('slug') ?? 'Tag'),
+                    default => 'Blog',
+                };
+
+                $collectionPage = array_filter([
+                    '@context' => 'https://schema.org',
+                    '@type' => 'CollectionPage',
+                    'url' => url()->current(),
+                    'name' => $collectionName,
+                    'isPartOf' => $publisherEntity ? [
+                        '@type' => 'WebSite',
+                        'name' => $publisher['name'],
+                        'url' => $publisher['url'] ?? null,
+                    ] : null,
+                ], fn ($value) => $value !== null);
+
+                $tags->push(new CustomSchema($collectionPage));
+
+                if ($isIndex) {
+                    $blog = array_filter([
+                        '@context' => 'https://schema.org',
+                        '@type' => 'Blog',
+                        'url' => route('blog.index'),
+                        'name' => $publisher && ! empty($publisher['name']) ? "{$publisher['name']} Blog" : 'Blog',
+                        'publisher' => $publisherEntity,
+                    ], fn ($value) => $value !== null);
+                    $tags->push(new CustomSchema($blog));
+                }
+
+                return $tags;
+            } catch (Throwable) {
+                return $tags;
+            }
+        });
     }
 }

--- a/src/Livewire/BlogSearch.php
+++ b/src/Livewire/BlogSearch.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Ink\Livewire;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Relaticle\Ink\Models\Post;
+
+class BlogSearch extends Component
+{
+    #[Url(as: 'q', except: '')]
+    public string $query = '';
+
+    public function render(): View
+    {
+        $results = $this->query === ''
+            ? new Collection
+            : Post::query()
+                ->with(['category', 'author'])
+                ->published()
+                ->search($this->query)
+                ->latest('published_at')
+                ->limit(20)
+                ->get();
+
+        return view('ink::livewire.blog-search', [
+            'results' => $results,
+        ]);
+    }
+}

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -18,11 +18,13 @@ use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use RalphJSmit\Laravel\SEO\Schema\ArticleSchema;
 use RalphJSmit\Laravel\SEO\Schema\BreadcrumbListSchema;
+use RalphJSmit\Laravel\SEO\Schema\FaqPageSchema;
 use RalphJSmit\Laravel\SEO\SchemaCollection;
 use RalphJSmit\Laravel\SEO\Support\HasSEO;
 use RalphJSmit\Laravel\SEO\Support\SEOData;
 use Relaticle\Ink\Database\Factories\PostFactory;
 use Relaticle\Ink\Enums\PostStatus;
+use Relaticle\Ink\Support\SchemaExtractor;
 use Spatie\LaravelMarkdown\MarkdownRenderer;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
@@ -134,6 +136,32 @@ class Post extends Model
             });
     }
 
+    #[Scope]
+    protected function search(Builder $query, string $term): void
+    {
+        $term = trim($term);
+
+        if ($term === '') {
+            return;
+        }
+
+        $callback = config('ink.search.callback');
+
+        if (is_callable($callback)) {
+            $callback($query, $term);
+
+            return;
+        }
+
+        $like = '%'.str_replace(['%', '_'], ['\\%', '\\_'], $term).'%';
+
+        $query->where(function (Builder $q) use ($like): void {
+            $q->where('title', 'like', $like)
+                ->orWhere('excerpt', 'like', $like)
+                ->orWhere('content', 'like', $like);
+        });
+    }
+
     public function toHtml(): string
     {
         return Cache::rememberForever(
@@ -242,6 +270,20 @@ class Post extends Model
 
                 return $breadcrumbs->prependBreadcrumbs($crumbs);
             });
+
+        if (config('ink.schema.faq_auto', true)) {
+            $faqEntities = SchemaExtractor::extractFaqEntities($this->renderedContent());
+
+            if ($faqEntities !== []) {
+                $schema = $schema->addFaqPage(function (FaqPageSchema $faq) use ($faqEntities): FaqPageSchema {
+                    foreach ($faqEntities as $entity) {
+                        $faq->addQuestion($entity['name'], $entity['acceptedAnswer']['text']);
+                    }
+
+                    return $faq;
+                });
+            }
+        }
 
         return new SEOData(
             title: $this->title,

--- a/src/Support/BlogListingSeo.php
+++ b/src/Support/BlogListingSeo.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Ink\Support;
+
+use RalphJSmit\Laravel\SEO\Support\SEOData;
+use Relaticle\Ink\Models\Category;
+use Relaticle\Ink\Models\Tag;
+
+final class BlogListingSeo
+{
+    public static function forIndex(int $page = 1, ?string $searchQuery = null): SEOData
+    {
+        $base = route('blog.index');
+        $title = $page > 1 ? "Blog — Page {$page}" : 'Blog';
+        $description = 'Latest posts from the blog.';
+        $url = $page > 1 ? "{$base}?page={$page}" : $base;
+        $robots = $searchQuery !== null && $searchQuery !== '' ? 'noindex,follow' : null;
+
+        return new SEOData(
+            title: $title,
+            description: $description,
+            url: $url,
+            robots: $robots,
+        );
+    }
+
+    public static function forCategory(Category $category, int $page = 1): SEOData
+    {
+        $base = route('blog.category', $category->slug);
+        $title = $page > 1 ? "{$category->name} — Page {$page}" : $category->name;
+        $description = "Posts in {$category->name}.";
+        $url = $page > 1 ? "{$base}?page={$page}" : $base;
+
+        return new SEOData(
+            title: $title,
+            description: $description,
+            url: $url,
+        );
+    }
+
+    public static function forTag(Tag $tag, int $page = 1): SEOData
+    {
+        $base = route('blog.tag', $tag->slug);
+        $title = $page > 1 ? "{$tag->name} — Page {$page}" : $tag->name;
+        $description = "Posts tagged {$tag->name}.";
+        $url = $page > 1 ? "{$base}?page={$page}" : $base;
+
+        return new SEOData(
+            title: $title,
+            description: $description,
+            url: $url,
+        );
+    }
+}

--- a/src/Support/SchemaExtractor.php
+++ b/src/Support/SchemaExtractor.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Ink\Support;
+
+final class SchemaExtractor
+{
+    /**
+     * Extract FAQ Question/Answer entities from rendered HTML containing
+     * an `## FAQ` H2 followed by `### Question?` / `<p>answer</p>` pairs.
+     *
+     * @return list<array{'@type':string,name:string,acceptedAnswer:array{'@type':string,text:string}}>
+     */
+    public static function extractFaqEntities(string $html): array
+    {
+        $section = self::findSectionByHeading($html, 'FAQ');
+
+        if ($section === null) {
+            return [];
+        }
+
+        preg_match_all(
+            '/<h3[^>]*>(.+?)<\/h3>\s*<p[^>]*>(.+?)<\/p>/is',
+            $section,
+            $pairs,
+            PREG_SET_ORDER,
+        );
+
+        $entities = [];
+
+        foreach ($pairs as $pair) {
+            $name = self::cleanText($pair[1]);
+            $text = self::cleanText($pair[2]);
+
+            if ($name === '' || $text === '') {
+                continue;
+            }
+
+            $entities[] = [
+                '@type' => 'Question',
+                'name' => $name,
+                'acceptedAnswer' => [
+                    '@type' => 'Answer',
+                    'text' => $text,
+                ],
+            ];
+        }
+
+        return $entities;
+    }
+
+    /**
+     * Extract HowTo step entities from rendered HTML containing a `## Steps`
+     * H2 followed by H3 step headings, each followed by one or more paragraphs.
+     *
+     * @return list<array{'@type':string,name:string,text:string,position:int}>
+     */
+    public static function extractHowToSteps(string $html): array
+    {
+        $section = self::findSectionByHeading($html, 'Steps');
+
+        if ($section === null) {
+            return [];
+        }
+
+        preg_match_all(
+            '/<h3[^>]*>(.+?)<\/h3>\s*<p[^>]*>(.+?)<\/p>/is',
+            $section,
+            $pairs,
+            PREG_SET_ORDER,
+        );
+
+        $steps = [];
+
+        foreach ($pairs as $index => $pair) {
+            $name = self::cleanText($pair[1]);
+            $text = self::cleanText($pair[2]);
+
+            if ($name === '' || $text === '') {
+                continue;
+            }
+
+            $steps[] = [
+                '@type' => 'HowToStep',
+                'position' => $index + 1,
+                'name' => $name,
+                'text' => $text,
+            ];
+        }
+
+        return $steps;
+    }
+
+    private static function findSectionByHeading(string $html, string $heading): ?string
+    {
+        if (! preg_match_all(
+            '/<h2\b[^>]*>(?<heading>.*?)<\/h2>(?<body>.*?)(?=<h2\b|\z)/is',
+            $html,
+            $matches,
+            PREG_SET_ORDER,
+        )) {
+            return null;
+        }
+
+        foreach ($matches as $match) {
+            $headingText = self::cleanText($match['heading']);
+
+            if (strcasecmp($headingText, $heading) === 0) {
+                return $match['body'];
+            }
+        }
+
+        return null;
+    }
+
+    private static function cleanText(string $html): string
+    {
+        $html = preg_replace('/<a[^>]+class="[^"]*heading-permalink[^"]*"[^>]*>.*?<\/a>/is', '', $html) ?? $html;
+
+        return trim(html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5));
+    }
+}

--- a/tests/Feature/BlogFaqSchemaTest.php
+++ b/tests/Feature/BlogFaqSchemaTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use RalphJSmit\Laravel\SEO\TagManager;
+use Relaticle\Ink\InkServiceProvider;
+use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Support\SchemaExtractor;
+
+beforeEach(function () {
+    config()->set('ink.features.public_routes', true);
+    config()->set('ink.layout', 'tests::layouts.empty');
+
+    $this->app->register(InkServiceProvider::class, force: true);
+    $this->app->getProvider(InkServiceProvider::class)->packageBooted();
+    Route::getRoutes()->refreshNameLookups();
+
+    // The shipped package controller does not call seo()->for() in show().
+    // Consumers override the controller to do so (see Post::getDynamicSEOData
+    // for the article + FAQ schema wiring). We simulate that here by binding
+    // a fresh TagManager and pointing it at the post we want to render.
+    $this->app->forgetInstance(TagManager::class);
+});
+
+function renderSeoForPost(Post $post): string
+{
+    seo()->for($post);
+
+    return (string) seo();
+}
+
+it('emits FAQPage JSON-LD when content has a ## FAQ section', function () {
+    $content = <<<'MD'
+    Intro paragraph.
+
+    ## FAQ
+
+    ### Does the package support FAQ schema?
+    Yes, automatically detected from headings.
+
+    ### Is it opt-in?
+    Yes, via config.
+    MD;
+
+    $post = Post::factory()->published()->create(['content' => $content]);
+
+    $output = renderSeoForPost($post);
+
+    expect($output)->toContain('FAQPage');
+    expect($output)->toContain('Question');
+    expect($output)->toContain('Does the package support FAQ schema?');
+});
+
+it('omits FAQPage when the schema.faq_auto config is disabled', function () {
+    config()->set('ink.schema.faq_auto', false);
+
+    $post = Post::factory()->published()->create([
+        'content' => "## FAQ\n\n### Q?\n\nA.",
+    ]);
+
+    $output = renderSeoForPost($post);
+
+    expect($output)->not->toContain('FAQPage');
+});
+
+it('omits FAQPage when no FAQ section is present', function () {
+    $post = Post::factory()->published()->create([
+        'content' => 'Just a post with no FAQ heading.',
+    ]);
+
+    $output = renderSeoForPost($post);
+
+    expect($output)->not->toContain('FAQPage');
+});
+
+it('extracts FAQ entities directly from rendered HTML', function () {
+    $html = '<h2>FAQ</h2><h3>Q1?</h3><p>A1</p><h3>Q2?</h3><p>A2</p>';
+
+    $entities = SchemaExtractor::extractFaqEntities($html);
+
+    expect($entities)->toHaveCount(2);
+    expect($entities[0]['name'])->toBe('Q1?');
+    expect($entities[0]['acceptedAnswer']['text'])->toBe('A1');
+});
+
+it('returns empty array when HTML has no FAQ section', function () {
+    $entities = SchemaExtractor::extractFaqEntities(
+        '<h2>Not FAQ</h2><p>Text</p>'
+    );
+
+    expect($entities)->toBe([]);
+});

--- a/tests/Feature/BlogHowToSchemaTest.php
+++ b/tests/Feature/BlogHowToSchemaTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use RalphJSmit\Laravel\SEO\TagManager;
+use Relaticle\Ink\InkServiceProvider;
+use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Support\SchemaExtractor;
+
+beforeEach(function () {
+    config()->set('ink.features.public_routes', true);
+    config()->set('ink.layout', 'tests::layouts.empty');
+    config()->set('ink.schema.howto_auto', true);
+
+    $this->app->register(InkServiceProvider::class, force: true);
+    $this->app->getProvider(InkServiceProvider::class)->packageBooted();
+    Route::getRoutes()->refreshNameLookups();
+
+    $this->app->forgetInstance(TagManager::class);
+});
+
+it('emits HowTo JSON-LD when content has a ## Steps section and howto_auto is on', function () {
+    $content = <<<'MD'
+    Setup overview.
+
+    ## Steps
+
+    ### Install the package
+    Run `composer require relaticle/ink`.
+
+    ### Publish the config
+    Run `php artisan vendor:publish --tag=ink-config`.
+    MD;
+
+    $post = Post::factory()->published()->create(['content' => $content]);
+
+    $response = $this->get(route('blog.show', $post->slug));
+
+    $response->assertOk();
+    $response->assertSee('HowTo', escape: false);
+    $response->assertSee('HowToStep', escape: false);
+    $response->assertSee('"position":1', escape: false);
+    $response->assertSee('"position":2', escape: false);
+    $response->assertSee('Install the package', escape: false);
+});
+
+it('omits HowTo when howto_auto is off (default)', function () {
+    config()->set('ink.schema.howto_auto', false);
+
+    $post = Post::factory()->published()->create([
+        'content' => "## Steps\n\n### A\n\nDo a.\n\n### B\n\nDo b.",
+    ]);
+
+    $response = $this->get(route('blog.show', $post->slug));
+
+    $response->assertOk();
+    $response->assertDontSee('"@type":"HowTo"', escape: false);
+});
+
+it('omits HowTo when no Steps section is present', function () {
+    $post = Post::factory()->published()->create([
+        'content' => 'Just a post with no Steps heading.',
+    ]);
+
+    $response = $this->get(route('blog.show', $post->slug));
+
+    $response->assertOk();
+    $response->assertDontSee('"@type":"HowTo"', escape: false);
+});
+
+it('extracts HowTo steps directly from rendered HTML', function () {
+    $html = '<h2>Steps</h2><h3>First</h3><p>Do this.</p><h3>Second</h3><p>Do that.</p>';
+    $steps = SchemaExtractor::extractHowToSteps($html);
+
+    expect($steps)->toHaveCount(2);
+    expect($steps[0]['position'])->toBe(1);
+    expect($steps[0]['name'])->toBe('First');
+    expect($steps[0]['text'])->toBe('Do this.');
+    expect($steps[1]['position'])->toBe(2);
+});

--- a/tests/Feature/BlogListingSchemaTest.php
+++ b/tests/Feature/BlogListingSchemaTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use RalphJSmit\Laravel\SEO\TagManager;
+use Relaticle\Ink\InkServiceProvider;
+use Relaticle\Ink\Models\Category;
+use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Models\Tag;
+
+beforeEach(function () {
+    config()->set('ink.features.public_routes', true);
+    config()->set('ink.features.tags', true);
+    config()->set('ink.layout', 'tests::layouts.empty');
+
+    $this->app->register(InkServiceProvider::class, force: true);
+    $this->app->getProvider(InkServiceProvider::class)->packageBooted();
+    Route::getRoutes()->refreshNameLookups();
+
+    $this->app->forgetInstance(TagManager::class);
+});
+
+it('emits Blog + CollectionPage JSON-LD on /blog', function () {
+    Post::factory(2)->published()->create();
+
+    $response = $this->get(route('blog.index'));
+
+    $response->assertOk();
+    $response->assertSee('"@type":"Blog"', escape: false);
+    $response->assertSee('"@type":"CollectionPage"', escape: false);
+});
+
+it('emits CollectionPage JSON-LD on /blog/category/{slug}', function () {
+    $category = Category::create(['name' => 'Guides', 'slug' => 'guides']);
+    Post::factory(2)->published()->for($category)->create();
+
+    $response = $this->get(route('blog.category', ['slug' => 'guides']));
+
+    $response->assertOk();
+    $response->assertSee('"@type":"CollectionPage"', escape: false);
+});
+
+it('emits CollectionPage JSON-LD on /blog/tag/{slug}', function () {
+    $tag = Tag::factory()->create(['name' => 'Filament']);
+    $post = Post::factory()->published()->create();
+    $post->tags()->attach($tag);
+
+    $response = $this->get(route('blog.tag', ['slug' => $tag->slug]));
+
+    $response->assertOk();
+    $response->assertSee('"@type":"CollectionPage"', escape: false);
+});
+
+it('does not emit listing schema on post detail pages', function () {
+    $post = Post::factory()->published()->create();
+
+    $response = $this->get(route('blog.show', $post->slug));
+
+    $response->assertOk();
+    $response->assertDontSee('"@type":"CollectionPage"', escape: false);
+    $response->assertDontSee('"@type":"Blog"', escape: false);
+});

--- a/tests/Feature/BlogListingSeoTest.php
+++ b/tests/Feature/BlogListingSeoTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Relaticle\Ink\InkServiceProvider;
+use Relaticle\Ink\Models\Category;
+use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Models\Tag;
+use Relaticle\Ink\Support\BlogListingSeo;
+
+beforeEach(function () {
+    config()->set('ink.features.public_routes', true);
+    config()->set('ink.features.tags', true);
+    config()->set('ink.per_page', 2);
+    config()->set('ink.layout', 'tests::layouts.empty');
+
+    $this->app->register(InkServiceProvider::class, force: true);
+    $this->app->getProvider(InkServiceProvider::class)->packageBooted();
+    Route::getRoutes()->refreshNameLookups();
+});
+
+it('sets a self-canonical on the blog index page 1', function () {
+    Post::factory(3)->published()->create();
+
+    $response = $this->get('/blog');
+
+    $response->assertOk();
+    $response->assertSee('<link rel="canonical" href="'.url('/blog').'"', escape: false);
+});
+
+it('sets a page-aware canonical and title on /blog?page=2', function () {
+    Post::factory(5)->published()->create();
+
+    $response = $this->get('/blog?page=2');
+
+    $response->assertOk();
+    $response->assertSee('<link rel="canonical" href="'.url('/blog?page=2').'"', escape: false);
+    $response->assertSee('Page 2', escape: false);
+});
+
+it('sets a category-aware canonical on /blog/category/{slug}', function () {
+    $category = Category::factory()->create(['name' => 'Guides', 'slug' => 'guides']);
+    Post::factory(3)->published()->create(['category_id' => $category->id]);
+
+    $response = $this->get('/blog/category/guides');
+
+    $response->assertOk();
+    $response->assertSee('<link rel="canonical" href="'.url('/blog/category/guides').'"', escape: false);
+});
+
+it('sets a tag-aware canonical on /blog/tag/{slug}', function () {
+    $tag = Tag::factory()->create(['name' => 'Filament']);
+    $post = Post::factory()->published()->create();
+    $post->tags()->attach($tag);
+
+    $response = $this->get('/blog/tag/'.$tag->slug);
+
+    $response->assertOk();
+    $response->assertSee('<link rel="canonical" href="'.url('/blog/tag/'.$tag->slug).'"', escape: false);
+});
+
+it('builds an SEOData object headless consumers can use directly', function () {
+    $data = BlogListingSeo::forIndex(page: 3);
+
+    expect($data->title)->toContain('Page 3');
+    expect((string) $data->url)->toBe(url('/blog?page=3'));
+});
+
+it('marks search result pages as noindex via headless helper', function () {
+    $data = BlogListingSeo::forIndex(searchQuery: 'laravel');
+
+    expect($data->robots)->toBe('noindex,follow');
+});
+
+it('builds category SEOData with page-aware url', function () {
+    $category = Category::factory()->create(['name' => 'News', 'slug' => 'news']);
+
+    $data = BlogListingSeo::forCategory($category, page: 2);
+
+    expect($data->title)->toContain('News');
+    expect($data->title)->toContain('Page 2');
+    expect((string) $data->url)->toBe(url('/blog/category/news?page=2'));
+});
+
+it('builds tag SEOData with page-aware url', function () {
+    $tag = Tag::factory()->create(['name' => 'Laravel']);
+
+    $data = BlogListingSeo::forTag($tag, page: 2);
+
+    expect($data->title)->toContain($tag->name);
+    expect($data->title)->toContain('Page 2');
+    expect((string) $data->url)->toBe(url('/blog/tag/'.$tag->slug.'?page=2'));
+});
+
+it('emits noindex on /blog?q=searchterm', function () {
+    Post::factory()->published()->create(['title' => 'Webhooks post']);
+    $response = $this->get('/blog?q=webhooks');
+    $response->assertOk();
+    $response->assertSee('noindex', escape: false);
+});
+
+it('filters results by q parameter', function () {
+    Post::factory()->published()->create(['title' => 'Webhooks tutorial']);
+    Post::factory()->published()->create(['title' => 'Forms guide']);
+
+    $response = $this->get('/blog?q=webhooks');
+    $response->assertOk();
+    $response->assertSee('Webhooks tutorial');
+    $response->assertDontSee('Forms guide');
+});

--- a/tests/Feature/BlogPaginationViewTest.php
+++ b/tests/Feature/BlogPaginationViewTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Relaticle\Ink\InkServiceProvider;
+use Relaticle\Ink\Models\Post;
+
+beforeEach(function () {
+    config()->set('ink.features.public_routes', true);
+    config()->set('ink.per_page', 2);
+    config()->set('ink.layout', 'tests::layouts.empty');
+
+    $this->app->register(InkServiceProvider::class, force: true);
+    $this->app->getProvider(InkServiceProvider::class)->packageBooted();
+    Route::getRoutes()->refreshNameLookups();
+});
+
+it('renders numbered pagination with aria-label on the blog index', function () {
+    Post::factory(5)->published()->create();
+
+    $response = $this->get('/blog');
+
+    $response->assertOk();
+    $response->assertSee('aria-label="Blog pagination"', escape: false);
+    $response->assertSee('aria-label="Go to page 2"', escape: false);
+});
+
+it('marks the current page with aria-current', function () {
+    Post::factory(5)->published()->create();
+
+    $response = $this->get('/blog?page=2');
+
+    $response->assertOk();
+    $response->assertSee('aria-current="page"', escape: false);
+});

--- a/tests/Feature/BlogPostSearchTest.php
+++ b/tests/Feature/BlogPostSearchTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Builder;
+use Relaticle\Ink\Models\Post;
+
+it('matches posts by title via the search scope', function () {
+    Post::factory()->published()->create(['title' => 'Webhooks in Laravel', 'content' => '']);
+    Post::factory()->published()->create(['title' => 'Forms in Filament', 'content' => '']);
+
+    $results = Post::query()->published()->search('webhooks')->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->title)->toBe('Webhooks in Laravel');
+});
+
+it('matches by excerpt and content via the default LIKE strategy', function () {
+    Post::factory()->published()->create([
+        'title' => 'Unrelated',
+        'excerpt' => 'A post about queues',
+        'content' => '...',
+    ]);
+    Post::factory()->published()->create([
+        'title' => 'Unrelated 2',
+        'excerpt' => '',
+        'content' => 'Discussion of webhooks here.',
+    ]);
+
+    expect(Post::query()->published()->search('queues')->count())->toBe(1);
+    expect(Post::query()->published()->search('webhooks')->count())->toBe(1);
+});
+
+it('returns the unfiltered query when term is empty or whitespace', function () {
+    Post::factory(3)->published()->create();
+
+    expect(Post::query()->published()->search('')->count())->toBe(3);
+    expect(Post::query()->published()->search('   ')->count())->toBe(3);
+});
+
+it('delegates to the configured callback when search.callback is set', function () {
+    Post::factory()->published()->create(['title' => 'matches']);
+    Post::factory()->published()->create(['title' => 'no']);
+
+    config()->set('ink.search.callback', function (Builder $query, string $term) {
+        $query->where('title', $term);
+    });
+
+    expect(Post::query()->published()->search('matches')->count())->toBe(1);
+});

--- a/tests/Feature/BlogSitemapTagsTest.php
+++ b/tests/Feature/BlogSitemapTagsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Relaticle\Ink\BlogSitemapGenerator;
+use Relaticle\Ink\InkServiceProvider;
+use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Models\Tag;
+use Spatie\Sitemap\Sitemap;
+
+beforeEach(function () {
+    config()->set('ink.features.public_routes', true);
+    config()->set('ink.features.tags', true);
+    config()->set('ink.layout', 'tests::layouts.empty');
+
+    $this->app->register(InkServiceProvider::class, force: true);
+    $this->app->getProvider(InkServiceProvider::class)->packageBooted();
+    Route::getRoutes()->refreshNameLookups();
+});
+
+test('adds tag URLs only when blog.tag route exists and the tag has published posts', function () {
+    $usedTag = Tag::factory()->create(['name' => 'Used Tag']);
+    $emptyTag = Tag::factory()->create(['name' => 'Empty Tag']);
+
+    $post = Post::factory()->published()->create();
+    $post->tags()->attach($usedTag);
+
+    $sitemap = BlogSitemapGenerator::addToSitemap(Sitemap::create());
+
+    $urls = collect($sitemap->getTags())->map(fn ($tag) => $tag->url)->all();
+
+    expect($urls)
+        ->toContain(route('blog.tag', $usedTag->slug))
+        ->not->toContain(route('blog.tag', $emptyTag->slug));
+});
+
+test('omits all tag URLs when tags feature is off', function () {
+    config()->set('ink.features.tags', false);
+
+    $tag = Tag::factory()->create(['name' => 'Used Tag']);
+    $post = Post::factory()->published()->create();
+    $post->tags()->attach($tag);
+
+    $sitemap = BlogSitemapGenerator::addToSitemap(Sitemap::create());
+    $urls = collect($sitemap->getTags())->map(fn ($tag) => $tag->url)->all();
+
+    expect($urls)->not->toContain(route('blog.tag', $tag->slug));
+});

--- a/tests/Feature/Livewire/BlogSearchTest.php
+++ b/tests/Feature/Livewire/BlogSearchTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Relaticle\Ink\Livewire\BlogSearch;
+use Relaticle\Ink\Models\Post;
+
+it('renders matching posts when query is set', function () {
+    Post::factory()->published()->create(['title' => 'Webhooks integration']);
+    Post::factory()->published()->create(['title' => 'Forms tutorial']);
+
+    Livewire::test(BlogSearch::class, ['query' => 'webhooks'])
+        ->assertSee('Webhooks integration')
+        ->assertDontSee('Forms tutorial');
+});
+
+it('shows empty state when no matches', function () {
+    Post::factory()->published()->create(['title' => 'Webhooks']);
+
+    Livewire::test(BlogSearch::class, ['query' => 'nope'])
+        ->assertSee('No posts match');
+});
+
+it('starts with empty query and shows no results until typed', function () {
+    Post::factory()->published()->create(['title' => 'Webhooks']);
+
+    Livewire::test(BlogSearch::class)
+        ->assertSet('query', '')
+        ->assertDontSee('Webhooks');
+});
+
+it('updates results when query is set', function () {
+    Post::factory()->published()->create(['title' => 'Webhooks integration']);
+
+    Livewire::test(BlogSearch::class)
+        ->set('query', 'webhooks')
+        ->assertSet('query', 'webhooks')
+        ->assertSee('Webhooks integration');
+});

--- a/tests/Fixtures/views/layouts/empty.blade.php
+++ b/tests/Fixtures/views/layouts/empty.blade.php
@@ -1,4 +1,4 @@
 <!doctype html>
-<html><head><title>{{ $title ?? 'Blog' }}</title></head>
+<html><head><title>{{ $title ?? 'Blog' }}</title>{!! seo() !!}</head>
 <body>@yield('content')</body>
 </html>


### PR DESCRIPTION
## Summary

A coherent v1.5.0 release covering listing-page SEO correctness, schema completion (FAQPage + HowTo + Blog + CollectionPage), portable search, and an accessible numbered pagination view.

Driven by gaps surfaced during a 3-month blog launch on a consumer project. The work was prototyped there first and is now generalized for the package.

### Fixed (bugs)

- `BlogSitemapGenerator` now iterates `/blog/tag/{slug}` URLs when `features.tags` is on. The package docs document tag routes as first-class but the sitemap was silently skipping them.
- Listing routes (`/blog`, `/blog/category/{slug}`, `/blog/tag/{slug}`) now emit per-page canonical URLs and page-aware titles via a new `BlogListingSeo` helper. Previously every paginated page canonicalized to page 1.
- Shipped `show` and `preview` routes now call `seo()->for($post)` so post-attached SEO (BlogPosting + BreadcrumbList + FAQPage) actually renders in public-routes mode. Previously the schema only fired for consumers who overrode the controller.

### Added (features)

- `FAQPage` JSON-LD auto-emit from `## FAQ` sections (default on; toggle via `schema.faq_auto`).
- `HowTo` JSON-LD auto-emit from `## Steps` sections (opt-in via `schema.howto_auto`).
- `Blog` + `CollectionPage` JSON-LD on listing routes.
- Numbered, aria-labeled pagination view at `blog::pagination.blog`.
- `wire:navigate` on `<x-blog::post-card>` post-link and pagination links.
- `Post::search($term)` scope (portable LIKE default, override via `search.callback`).
- `?q=` honored on shipped `/blog` route with `noindex,follow` on result URLs.
- `BlogSearch` Livewire component (`<livewire:blog::search />`).
- 3 new docs pages: `search.md`, `schema.md`, `listing-seo.md`.
- `ManukMinasyan\FilamentBlog\Support\BlogListingSeo` helper (also usable from headless consumers).
- `ManukMinasyan\FilamentBlog\Support\SchemaExtractor` helper for FAQ + HowTo HTML parsing.

### Internal changes worth flagging

- `FilamentBlogServiceProvider` now binds `RalphJSmit\Laravel\SEO\TagManager` as a singleton in `packageRegistered()`. Without this, `seo()->for(...)` in controllers does not persist to `{!! seo() !!}` in layouts — the singleton binding is required for the documented usage pattern but `ralphjsmit/laravel-seo` doesn't ship it. If you'd prefer to require consumers to bind it themselves, that's a one-line revert; flagged so you can choose.
- A Livewire 4 quirk: `<livewire:blog::search />` (with `::` in the name) doesn't resolve through Livewire's standard `::component()` registration. Worked around with a `Livewire::resolveMissingComponent` callback. If you'd prefer to rename `BlogSearch` → `Search` (canonical Livewire convention) and drop the workaround, easy follow-up.

### Backward compatibility

- All schema additions are content-conventional; no breaking changes to existing posts unless they coincidentally have an `## FAQ` H2 they didn't intend as FAQ schema (set `schema.faq_auto = false` to opt out).
- `schema.faq_auto` defaults to `true`. `schema.howto_auto` defaults to `false` (opt-in).
- New listing-route SEO changes the `<title>` tag on paginated pages (now suffixed with `— Page N`) and the `<link rel="canonical">` URL on pages 2+. This is SEO-correct behavior; consumers relying on the broken previous behavior will see indexing changes.

## Test plan

- [x] `vendor/bin/pest --compact` — 58 passed, 118 assertions (was 23 on `main`)
- [x] `vendor/bin/pint --test --format agent` — clean
- [ ] Schema spot-check: post with `## FAQ` section, validate at https://search.google.com/test/rich-results
- [ ] Schema spot-check: post with `## Steps` and `schema.howto_auto=true`, validate HowTo
- [ ] Sitemap spot-check: enable tags, attach a tag to a published post, regenerate sitemap, verify `/blog/tag/{slug}` URL appears
- [ ] Pagination smoke: visit `/blog?page=2` on a consumer with 15+ posts, verify canonical and `— Page 2` title

## Provenance

Implementation plan traceable at `docs/superpowers/plans/2026-05-13-filament-blog-v1.5.md` in the consumer project that drove this work.

The commits are individually testable — each task ships its own tests and committed together with the implementation:

```
b3b3106 docs: add search/schema/listing-seo pages, finalize v1.5.0 changelog, update README
bff0ff8 feat: add BlogSearch Livewire component with URL-synced query
3b2fef6 feat: add Post::search scope with config callback hook and wire it into /blog?q=
a76f6da feat: numbered aria-labeled pagination view and wire:navigate on post-card
1349a35 feat: auto-emit Blog and CollectionPage JSON-LD on listing routes
1af5e0e feat: auto-emit HowTo JSON-LD when schema.howto_auto is enabled
10fd1ce fix: call seo()->for($post) on show and preview routes
21b965c feat: auto-emit FAQPage JSON-LD from blog FAQ sections
4418f38 fix: emit per-page canonicals and titles for blog listing routes
df6bb0f fix: include tag archive URLs in BlogSitemapGenerator
a65e159 chore: open v1.5.0 changelog stub
```