### PR TITLE
feat: host-owned views

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.4']
-        laravel: ['^12.0']
+        laravel: ['^13.0']
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.1.0] - Unreleased
+## [2.3.0] - 2026-08-06
+
+### Added
+- Host-owned views: an `ink.views` config map lets a host point any of the six public-routes actions (`index`, `show`, `category`, `tag`, `preview`, `feed`) at a view it already owns, instead of rendering ink's own `ink::pages.*` views. Every key defaults to `null` and is purely additive — see [Host-Owned Views](https://relaticle.github.io/ink/essentials/host-owned-views).
+- `ink.middleware` config key for the blog route group, defaulting to `['web']`. Add your own middleware (e.g. a response transformer for AI crawlers) alongside it.
+- `preview()` now passes `relatedPosts` and `editUrl` to the view. Register `Ink::resolvePreviewEditUrlUsing()` in a service provider's `boot()` to supply the edit link; ink's own preview page now renders it via `<x-ink::preview-banner>`, matching the contract host-owned preview views already had.
+- `Post::tableOfContents(string $tag = 'h2')` builds a `fragment => heading text` map from the rendered post, for hosts building an in-page table of contents. Restricted to `h1`-`h6`; any other value throws `InvalidArgumentException`.
+- `show()` and `preview()` now eager-load `tags` on the post, so `$post->tags` no longer triggers a lazy-load query in either view.
+
+### Changed
+- `/blog/preview/{post}` now constrains `{post}` to `[0-9]{1,18}` (the safe maximum for a signed 64-bit id) instead of the unbounded `whereNumber()`, closing a public unauthenticated 500 that an over-long digit segment could trigger via a `bigint` overflow on Postgres.
+- `blog.feed` is now registered only when `features.feed` is `true`, instead of always being registered behind a runtime `abort_unless()` check.
+
+See [UPGRADING.md](UPGRADING.md) for the full migration notes, including the `route:cache` implication of the `blog.feed` change.
+
+## [2.2.0] - 2026-08-06
+
+### Added
+- First-class MCP support: a shippable `BlogServer`, tool authorization through the host's `Gate` instead of a hardcoded `is_admin` check, and an `Ink::resolveAuthorUsing()` hook for hosts whose staff aren't `ink.author_model` instances.
+
+### Changed
+- MCP tools now store markdown instead of pre-rendering to HTML, matching what the Filament editor already stored. The included migration converts existing HTML rows.
+
+### Fixed
+- Long unbreakable tokens (URLs, code identifiers) in a post title no longer overflow the post page layout.
+- JSON-LD structured data now escapes `</script>`, `&`, `'` and `"`, closing an injection hole where a post title or excerpt containing `</script>` broke out of the schema block and rendered as visible page text.
+- The default `show` and `preview` views now strip raw HTML from post content before rendering markdown, closing a stored-XSS hole where a `<script>` in a post body executed on the public page.
+
+## [2.1.1] - 2026-08-04
+
+### Changed
+- Widened the `spatie/laravel-sluggable` constraint to allow `^4`.
+
+## [2.1.0] - 2026-05-14
 
 ### Added
 - `Relaticle\Ink\Support\BlogListingSeo` helper for building per-page `SEOData` for listings. Headless consumers can call `BlogListingSeo::forIndex/forCategory/forTag` from their own controllers.
@@ -21,7 +54,7 @@ All notable changes to this project will be documented in this file.
 - Listing routes (`/blog`, `/blog/category/{slug}`, `/blog/tag/{slug}`) now emit per-page canonical URLs and page-aware titles. Previously every paginated page canonicalized to page 1, causing Google to treat pages 2+ as duplicate content.
 - Shipped `show` and `preview` routes now call `seo()->for($post)` so post-attached SEO (BlogPosting + BreadcrumbList + FAQPage JSON-LD) actually renders in public-routes mode. Previously the schema only worked for consumers who overrode the controller.
 
-## [2.0.0] - Unreleased
+## [2.0.0] - 2026-05-14
 
 ### Changed (BREAKING)
 - **Package renamed** from `manukminasyan/filament-blog` to `relaticle/ink`

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ Filament-native content publishing for blog, docs, and AI-citable articles. Ship
 - **Two install modes**
   - **Headless (default)** — define your own routes/controllers, use the Blade components
   - **Public-routes mode (opt-in)** — flip a config flag, get `/blog`, `/blog/{slug}`, `/blog/category/{slug}`, signed `/blog/preview/{post}`, and optional `/blog/feed`
+- **Host-owned views** — point the `views` config map at your app's own views per action, without publishing; register `Ink::resolvePreviewEditUrlUsing()` to control the preview page's edit link
 - **Tags taxonomy** (opt-in via `features.tags`) — many-to-many `blog_post_tag` table, `TagResource` admin UI, public archive at `/blog/tag/{slug}`
 - **MediaLibrary integration** (opt-in via `features.media_library`) — when both the flag is on AND `spatie/laravel-medialibrary` is installed, the featured-image upload uses `SpatieMediaLibraryFileUpload` instead of the plain `FileUpload`. Falls back gracefully if MediaLibrary isn't installed.
 - **Sitemap Generator** — Route-aware sitemap integration via spatie/laravel-sitemap
-- **Reading-time + related-posts** helpers on the Post model
+- **Reading-time, related-posts, and table-of-contents** helpers on the Post model
 
 ## Requirements
 
@@ -67,11 +68,17 @@ To get a working blog at `/blog` without writing any controllers, flip the featu
 
 Routes register at the service-provider level — no Filament panel boot is required, so the public site keeps working for guests who never touch the admin.
 
-Publish the views if you want to customize them:
+Render your own views instead of the shipped ones by pointing the `views` config map at them — no publishing required:
 
-```bash
-php artisan vendor:publish --tag=ink-views
+```php
+// config/ink.php
+'views' => [
+    'show' => 'blog.show',
+    'preview' => 'blog.preview',
+],
 ```
+
+See [Host-Owned Views](https://relaticle.github.io/ink/essentials/host-owned-views) for the full data contract per action and for wiring the preview "edit this post" link.
 
 ## Documentation
 
@@ -83,6 +90,7 @@ php artisan vendor:publish --tag=ink-views
 - [Filament Admin](https://relaticle.github.io/ink/essentials/filament-admin)
 - [MCP Tools](https://relaticle.github.io/ink/essentials/mcp-tools)
 - [Configuration](https://relaticle.github.io/ink/essentials/configuration)
+- [Host-Owned Views](https://relaticle.github.io/ink/essentials/host-owned-views)
 
 ## Quick Example (headless)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,82 @@
 # Upgrading
 
+## To 2.3 from 2.2
+
+### Host-owned views for public-routes mode
+
+`BlogController`'s six actions used to render only the package's own `ink::pages.*` views.
+A new `views` config key lets you point each action at a view your app already owns instead:
+
+```php
+// config/ink.php
+'views' => [
+    'index' => null,
+    'show' => null,
+    'category' => null,
+    'tag' => null,
+    'preview' => null,
+    'feed' => null,
+],
+```
+
+Every key defaults to `null`, which keeps rendering `ink::pages.*` exactly as before — this
+key is purely additive and requires no action from existing installs.
+
+See [Host-Owned Views](https://relaticle.github.io/ink/essentials/host-owned-views) for the
+full per-action view-data contract.
+
+### Route middleware is configurable
+
+The blog route group's middleware was hardcoded to `['web']`. It now reads from a new
+`middleware` config key, defaulting to the same `['web']`:
+
+```php
+// config/ink.php
+'middleware' => ['web'],
+```
+
+Purely additive. Add your own middleware alongside `web` — for example a response
+transformer for AI crawlers.
+
+### Preview page: edit link and related posts
+
+`preview()` now passes `relatedPosts` and `editUrl` alongside `post`. `editUrl` is `null`
+unless you register a hook in a service provider's `boot()`:
+
+```php
+use Relaticle\Ink\Ink;
+use Relaticle\Ink\Models\Post;
+
+Ink::resolvePreviewEditUrlUsing(fn (Post $post): ?string =>
+    auth('sysadmin')->check()
+        ? PostResource::getUrl('edit', ['record' => $post], panel: 'sysadmin')
+        : null);
+```
+
+If your published `preview` view doesn't reference these keys, nothing breaks — Blade
+ignores extra view data. `show` and `preview` also now eager-load `tags` on the post, so
+`$post->tags` no longer triggers a lazy-load query in either view.
+
+### `blog.feed` route is no longer registered when the feature is off
+
+Previously the `blog.feed` route was always registered, and `feed()` called
+`abort_unless(config('ink.features.feed'), 404)` at request time. The route is now
+registered only when `features.feed` is `true`; the runtime check is gone.
+
+For most hosts this is invisible — a disabled feed still 404s. It only matters if you were
+calling `route('blog.feed')` or `Route::has('blog.feed')` directly with the feature off:
+`Route::has(...)` now returns `false` instead of `true`, and `route('blog.feed')` now throws
+`RouteNotFoundException` instead of returning a URL that 404s when visited.
+
+`blog.tag` is unaffected by this change — its route still registers unconditionally and
+`tag()` still aborts at runtime when `features.tags` is off.
+
+### `/blog/preview/{post}` rejects non-numeric ids at the router
+
+The preview route now has `->whereNumber('post')`. A non-numeric segment now 404s at
+routing instead of reaching route-model binding, which could otherwise throw a database
+error on a strict-typed `id` column.
+
 ## To 2.2 from 2.1
 
 ### MCP tools authorize through your Gate

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -71,11 +71,19 @@ calling `route('blog.feed')` or `Route::has('blog.feed')` directly with the feat
 `blog.tag` is unaffected by this change — its route still registers unconditionally and
 `tag()` still aborts at runtime when `features.tags` is off.
 
+`features.feed` is now read once, at route-registration time, instead of on every
+request. If you run `route:cache`, flipping the flag from `false` to `true` (or back)
+requires `php artisan route:clear` (or a re-run of `route:cache`) before the change takes
+effect — previously the runtime check picked it up immediately on the next request.
+
 ### `/blog/preview/{post}` rejects non-numeric ids at the router
 
-The preview route now has `->whereNumber('post')`. A non-numeric segment now 404s at
-routing instead of reaching route-model binding, which could otherwise throw a database
-error on a strict-typed `id` column.
+The preview route now constrains `{post}` to `[0-9]{1,18}` (up to 18 digits — the safe
+maximum for a signed 64-bit id) instead of `whereNumber()`'s unbounded `[0-9]+`. A
+non-numeric segment 404s at routing instead of reaching route-model binding, which could
+otherwise throw a database error on a strict-typed `id` column; the length bound closes
+the same hole for an arbitrarily long digit string, which could otherwise overflow a
+`bigint` column on Postgres.
 
 ## To 2.2 from 2.1
 

--- a/config/ink.php
+++ b/config/ink.php
@@ -8,6 +8,21 @@ return [
 
     'layout' => 'layouts.app',
 
+    /*
+     * Render your own views instead of the package's. Each null falls back to
+     * the matching `ink::pages.*` view.
+     */
+    'views' => [
+        'index' => null,
+        'show' => null,
+        'category' => null,
+        'tag' => null,
+        'preview' => null,
+        'feed' => null,
+    ],
+
+    'middleware' => ['web'],
+
     'author_model' => User::class,
 
     'per_page' => 12,

--- a/docs/content/1.getting-started/2.frontend-setup.md
+++ b/docs/content/1.getting-started/2.frontend-setup.md
@@ -150,7 +150,29 @@ Useful in your views:
 $post->readingTime();       // int — minutes
 $post->relatedPosts(3);     // Builder of same-category, published, !=$this->id
 $post->getUrl();            // route('blog.show', $post->slug) if registered, else fallback
+$post->tableOfContents();   // array<string, string> — fragment => heading text, from <h2>
 ```
+
+`tableOfContents(string $tag = 'h2')` parses the **rendered** post (`$post->toHtml()`), not
+the markdown source, so a heading's full text is captured even when it contains inline
+markup (bold, code, links) — `## Using \`artisan\` commands` becomes `Using artisan
+commands`, not `Using` — and HTML entities decode exactly once. Each key is the fragment
+used by the heading's permalink anchor; each value is the heading's text:
+
+```blade [resources/views/blog/show.blade.php]
+@if ($toc = $post->tableOfContents())
+    <nav aria-label="Table of contents">
+        <ul>
+            @foreach ($toc as $fragment => $heading)
+                <li><a href="#{{ $fragment }}">{{ $heading }}</a></li>
+            @endforeach
+        </ul>
+    </nav>
+@endif
+```
+
+Pass `tag: 'h3'` (or any heading level your content uses) to build the TOC from a different
+level. A post with no matching headings returns an empty array.
 
 ## Expected route names
 

--- a/docs/content/1.getting-started/3.public-routes-mode.md
+++ b/docs/content/1.getting-started/3.public-routes-mode.md
@@ -13,7 +13,7 @@ The package ships an **opt-in public-routes mode**. Flip a flag in config and yo
 | `GET /blog/{slug}` | `blog.show` | Single post (only published) |
 | `GET /blog/category/{slug}` | `blog.category` | Category archive (paginated) |
 | `GET /blog/preview/{post}` | `blog.preview` | Signed-only draft preview, with `noindex,nofollow` meta |
-| `GET /blog/feed` | `blog.feed` | RSS 2.0 feed (gated by `features.feed`) |
+| `GET /blog/feed` | `blog.feed` | RSS 2.0 feed (route only registered when `features.feed` is true) |
 | `GET /blog/tag/{slug}` | `blog.tag` | Tag archive (gated by `features.tags`) |
 
 ## Enable it
@@ -49,24 +49,26 @@ The page views extend the layout you set in `'layout'`. It must define a `@yield
 </html>
 ```
 
-If your layout uses a different slot mechanism (e.g. Blade components with `{{ $slot }}`), publish the page views and adapt them:
-
-```bash [Terminal]
-php artisan vendor:publish --tag=ink-views
-```
+If your layout uses a different slot mechanism (e.g. Blade components with `{{ $slot }}`), point the [`views` config map](/essentials/host-owned-views) at views of your own — see the next section.
 
 ## Customizing pages
 
-The shipped pages live at:
+Point the `views` config map at views your app already owns, per action:
 
-- `resources/views/vendor/blog/pages/index.blade.php`
-- `resources/views/vendor/blog/pages/show.blade.php`
-- `resources/views/vendor/blog/pages/category.blade.php`
-- `resources/views/vendor/blog/pages/preview.blade.php`
-- `resources/views/vendor/blog/pages/tag.blade.php`
-- `resources/views/vendor/blog/pages/feed.blade.php`
+```php [config/ink.php]
+'views' => [
+    'show' => 'blog.show',
+    'preview' => 'blog.preview',
+],
+```
 
-Edit them freely — once published, the package no longer serves its own copies.
+Any key left `null` keeps rendering the package's own `ink::pages.*` view. See
+[Host-Owned Views](/essentials/host-owned-views) for the full data each action passes and
+for wiring the preview "edit this post" link.
+
+Publishing (`php artisan vendor:publish --tag=ink-views`) also works — Laravel resolves
+`resources/views/vendor/ink/**` ahead of the package's own views — but a published file is a
+frozen copy that stops receiving upstream fixes. Prefer the `views` map.
 
 ## Custom prefix
 
@@ -84,7 +86,14 @@ Each feature flag is independent:
 ],
 ```
 
-When a flag is off, requests to that path return **404** (not registered). `Route::has(...)` returns true (the route is defined) but the controller calls `abort_unless($flag, 404)`. That's a deliberate choice so route ordering stays predictable and you can probe the route name without crashing.
+When a flag is off, requests to that path return **404**, but not always for the same reason:
+
+- `features.feed` off — the `blog.feed` route is never registered. `Route::has('blog.feed')` returns `false`.
+- `features.tags` off — the `blog.tag` route is still registered (so `route('blog.tag', ...)` keeps resolving without throwing), but `tag()` calls `abort_unless($flag, 404)` at request time. `Route::has('blog.tag')` returns `true`.
+
+The tag route stays registered unconditionally so that `route('blog.tag', ...)` never throws
+a `RouteNotFoundException`, even with the feature off — only the controller enforces the
+flag.
 
 ## Mode comparison
 

--- a/docs/content/2.essentials/10.host-owned-views.md
+++ b/docs/content/2.essentials/10.host-owned-views.md
@@ -1,0 +1,129 @@
+---
+title: Host-Owned Views
+description: Render ink's controllers through views your app already owns, and control the preview edit link.
+navigation:
+  icon: i-lucide-layout-template
+---
+
+Public-routes mode ships a `BlogController` with all six public actions. By default they
+render the package's own `ink::pages.*` views. Point each action at a view your app already
+owns instead — same controller, same SEO and query behavior, your markup.
+
+## The `views` config map
+
+```php [config/ink.php]
+'views' => [
+    'index' => null,
+    'show' => null,
+    'category' => null,
+    'tag' => null,
+    'preview' => null,
+    'feed' => null,
+],
+```
+
+Every key defaults to `null`. A `null` or empty-string value falls back to the matching
+`ink::pages.*` view, so an existing install that never touches this key renders exactly as
+before. Set a key to any view name your app can resolve — a Blade view, a package view, a
+namespaced view from another provider:
+
+```php [config/ink.php]
+'views' => [
+    'index' => 'blog.index',
+    'show' => 'blog.show',
+    'preview' => 'blog.preview',
+],
+```
+
+Resolution happens once per request, through a private `viewFor()` helper on
+`BlogController` — every action calls it instead of hardcoding `ink::pages.*`.
+
+## What each view receives
+
+| Action | View data | Notes |
+|---|---|---|
+| `index` | `posts` | — |
+| `show` | `post`, `relatedPosts` | `post->tags` is eager-loaded |
+| `category` | `category`, `posts` | — |
+| `tag` | `tag`, `posts` | — |
+| `preview` | `post`, `relatedPosts`, `editUrl` | `post->tags` is eager-loaded; `editUrl` is `null` unless a host registers [`Ink::resolvePreviewEditUrlUsing()`](#preview-edit-link) |
+| `feed` | `posts` | — |
+
+`relatedPosts` and `editUrl` on `preview` are new — earlier versions passed only `post`.
+
+::caution
+Publishing views (`php artisan vendor:publish --tag=ink-views`) is not the recommended way
+to customize the six page views above. Laravel resolves `resources/views/vendor/ink/**`
+ahead of `ink::**` automatically, so publishing *works* — but the file it creates is a
+frozen copy of package markup from the day you published it. It will not receive upstream
+fixes, and nothing will tell you when it's drifted. Pointing `views` at your own view avoids
+both problems: you own the markup from the start, and ink's own pages keep improving
+underneath you without needing a merge.
+
+Publishing is still how you customize the [Blade components](/essentials/blade-components)
+(`post-card`, `post-header`, …) — those aren't covered by the `views` map.
+::
+
+## Preview edit link
+
+`Ink::resolvePreviewEditUrlUsing()` registers how to build the "edit this post" link shown
+on the preview page:
+
+```php
+public static function resolvePreviewEditUrlUsing(?Closure $callback): void
+```
+
+With nothing registered, `editUrl` is always `null` and no edit link renders. Register a
+callback in a service provider's `boot()` — never in config, since a closure in a config
+file breaks `config:cache`:
+
+```php
+use Relaticle\Ink\Ink;
+use Relaticle\Ink\Models\Post;
+
+Ink::resolvePreviewEditUrlUsing(fn (Post $post): ?string =>
+    auth('sysadmin')->check()
+        ? PostResource::getUrl('edit', ['record' => $post], panel: 'sysadmin')
+        : null);
+```
+
+The callback receives the `Post` and must return a string or `null`. A `null`, or any
+non-string return, is treated as "no link" — the resolver never throws on a misconfigured
+callback. Which panel and which guard own the blog admin is a host decision; ink does not
+guess at it.
+
+`<x-ink::preview-banner :post="$post" :editUrl="$editUrl" />` is the shipped component that
+renders this link.
+
+## Route middleware
+
+```php [config/ink.php]
+'middleware' => ['web'],
+```
+
+Applied to the entire blog route group. Add your own alongside it — for example a host that
+serves markdown to AI crawlers:
+
+```php [config/ink.php]
+'middleware' => ['web', ProvideMarkdownResponse::class],
+```
+
+## The shallow config-merge trap
+
+::caution
+If your app has already run `php artisan vendor:publish --tag=ink-config`, be aware that
+Laravel's `mergeConfigFrom` — which is how the package's config defaults reach your
+`config/ink.php` — is a **shallow** merge. It's `array_merge($packageDefaults, $yourConfig)`:
+for any top-level key present in both arrays, your value wins **wholesale**, array or not.
+
+New top-level keys like `views` and `middleware` merge in fine — your published file simply
+doesn't have them, so the package default fills the gap. But a key added *inside* an
+existing array, such as a new flag under `features`, will not reach you: your published
+`features` array replaces the package's entirely, new subkey and all. This isn't
+hypothetical — it already bit a host of this package: `ink.features.mcp` silently resolved
+to `null` after they'd published `config/ink.php` before that flag existed.
+
+After upgrading, diff your published `config/ink.php` against the package's
+[`config/ink.php`](https://github.com/relaticle/ink/blob/main/config/ink.php) and add any
+new subkeys by hand.
+::

--- a/docs/content/2.essentials/10.host-owned-views.md
+++ b/docs/content/2.essentials/10.host-owned-views.md
@@ -88,9 +88,11 @@ Ink::resolvePreviewEditUrlUsing(fn (Post $post): ?string =>
 ```
 
 The callback receives the `Post` and must return a string or `null`. A `null`, or any
-non-string return, is treated as "no link" — the resolver never throws on a misconfigured
-callback. Which panel and which guard own the blog admin is a host decision; ink does not
-guess at it.
+non-string return, is treated as "no link" — a misconfigured *return value* never throws.
+If your callback itself throws, that exception is not caught and will surface as a 500 on
+the preview page; ink only guards the return value, not the callback's own execution.
+Which panel and which guard own the blog admin is a host decision; ink does not guess at
+it.
 
 `<x-ink::preview-banner :post="$post" :editUrl="$editUrl" />` is the shipped component that
 renders this link.

--- a/docs/content/2.essentials/4.configuration.md
+++ b/docs/content/2.essentials/4.configuration.md
@@ -11,6 +11,13 @@ Publish the config file:
 php artisan vendor:publish --tag=ink-config
 ```
 
+::caution
+Once published, new **top-level** keys the package adds in later releases (like `views` and
+`middleware`) merge into your config automatically. New keys added *inside* an existing
+array such as `features` do not — see [the shallow-merge trap](/essentials/host-owned-views#the-shallow-config-merge-trap)
+for why, and re-check your published file after every upgrade.
+::
+
 ## Full reference
 
 ```php [config/ink.php]
@@ -33,6 +40,31 @@ return [
     | mode.
     */
     'layout' => 'layouts.app',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Host-owned views
+    |--------------------------------------------------------------------------
+    | Render each public-routes action through a view your app owns instead of
+    | the package's own ink::pages.*. A null (or empty string) falls back to
+    | the matching ink::pages.* view. See: essentials/host-owned-views
+    */
+    'views' => [
+        'index' => null,
+        'show' => null,
+        'category' => null,
+        'tag' => null,
+        'preview' => null,
+        'feed' => null,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Route middleware
+    |--------------------------------------------------------------------------
+    | Applied to the whole blog route group.
+    */
+    'middleware' => ['web'],
 
     /*
     |--------------------------------------------------------------------------
@@ -162,7 +194,13 @@ The generator is route-aware — it only adds URLs for routes that exist in your
 
 ## Customizing views
 
-Publish all Blade page + component views:
+For the six public-routes pages (`index`, `show`, `category`, `tag`, `preview`, `feed`),
+point the `views` config map at views your app already owns — see
+[Host-Owned Views](/essentials/host-owned-views). It avoids publishing a copy of package
+markup that stops receiving upstream fixes.
+
+For the Blade components used in headless mode (`post-card`, `post-header`, …), publishing
+is the only route:
 
 ```bash [Terminal]
 php artisan vendor:publish --tag=ink-views
@@ -170,7 +208,7 @@ php artisan vendor:publish --tag=ink-views
 
 Published files go to:
 - `resources/views/vendor/blog/components/` — the publishable components used in headless mode
-- `resources/views/vendor/blog/pages/` — the page views used in public-routes mode
+- `resources/views/vendor/blog/pages/` — the page views used in public-routes mode (prefer the `views` config map instead — see above)
 
 Edit them to match your design system. Once published, the package no longer serves its own copies of those files.
 

--- a/docs/content/2.essentials/4.configuration.md
+++ b/docs/content/2.essentials/4.configuration.md
@@ -207,8 +207,8 @@ php artisan vendor:publish --tag=ink-views
 ```
 
 Published files go to:
-- `resources/views/vendor/blog/components/` — the publishable components used in headless mode
-- `resources/views/vendor/blog/pages/` — the page views used in public-routes mode (prefer the `views` config map instead — see above)
+- `resources/views/vendor/ink/components/` — the publishable components used in headless mode
+- `resources/views/vendor/ink/pages/` — the page views used in public-routes mode (prefer the `views` config map instead — see above)
 
 Edit them to match your design system. Once published, the package no longer serves its own copies of those files.
 

--- a/docs/content/2.essentials/5.tags.md
+++ b/docs/content/2.essentials/5.tags.md
@@ -87,7 +87,7 @@ When both `features.public_routes` and `features.tags` are on, the route `/blog/
 Route::get('/tag/{slug}', [BlogController::class, 'tag'])->name('blog.tag');
 ```
 
-The shipped view at `resources/views/vendor/blog/pages/tag.blade.php` uses the `<x-ink::post-card>` component. Publish and edit it to customize.
+The shipped view at `resources/views/vendor/ink/pages/tag.blade.php` uses the `<x-ink::post-card>` component. Publish and edit it to customize.
 
 ## Disabling tags after enabling
 

--- a/docs/superpowers/plans/2026-08-06-host-owned-views.md
+++ b/docs/superpowers/plans/2026-08-06-host-owned-views.md
@@ -56,7 +56,7 @@ HOST INDEX: {{ $posts->total() }} posts
 Create `tests/Fixtures/views/host-show.blade.php`:
 
 ```blade
-HOST SHOW: {{ $post->title }} / related={{ $relatedPosts->count() }} / tags={{ $post->tags->count() }}
+HOST SHOW: {{ $post->title }} / related={{ $relatedPosts->count() }}
 ```
 
 Create `tests/Feature/HostViewsTest.php`:
@@ -157,7 +157,7 @@ Then replace each hardcoded view name:
 - [ ] **Step 5: Run test to verify it passes**
 
 Run: `vendor/bin/pest tests/Feature/HostViewsTest.php`
-Expected: 3 passed. The show test still fails on `$post->tags` — that is Task 2.
+Expected: 3 passed.
 
 - [ ] **Step 6: Commit**
 
@@ -189,6 +189,12 @@ Create `tests/Fixtures/views/host-preview.blade.php`:
 
 ```blade
 HOST PREVIEW: {{ $post->title }} / related={{ $relatedPosts->count() }} / edit={{ $editUrl ?? 'none' }}
+```
+
+Extend `tests/Fixtures/views/host-show.blade.php` to exercise the eager-loaded tags:
+
+```blade
+HOST SHOW: {{ $post->title }} / related={{ $relatedPosts->count() }} / tags={{ $post->tags->count() }}
 ```
 
 Append to `tests/Feature/HostViewsTest.php`:

--- a/docs/superpowers/plans/2026-08-06-host-owned-views.md
+++ b/docs/superpowers/plans/2026-08-06-host-owned-views.md
@@ -1,0 +1,712 @@
+# Host-Owned Views Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a host render its own views through ink's controllers, so it never duplicates or publishes package files.
+
+**Architecture:** A config map of view names replaces the hardcoded `ink::pages.*` in `BlogController`; `null` keeps today's behaviour. Two data gaps close (`relatedPosts` and an edit-URL hook on preview, `tags` eager-loaded). Route middleware becomes configurable, the preview route constrains `{post}` to digits, and the feed route registers only when its flag is on (the tag route stays registered — an existing test resolves it while the feature is off). The table-of-contents parser moves onto `Post`, next to the `toHtml()` output it reads.
+
+**Tech Stack:** PHP 8.4, Laravel 13, Pest 5, Orchestra Testbench 11.
+
+## Global Constraints
+
+- Target branch `2.x`, released as **v2.3.0**. Additive for hosts on ink's own views.
+- Config holds plain strings and class-strings only — never closures. Host callables go on the `Ink` manager in a provider's `boot()`.
+- `null` in `ink.views.*` must fall back to `ink::pages.*`, so an existing host upgrading changes nothing.
+- Every task ends green: `vendor/bin/pest` and `vendor/bin/pint --test` both pass before committing.
+- Existing route names (`blog.index`, `blog.show`, `blog.category`, `blog.tag`, `blog.preview`, `blog.feed`) do not change.
+
+---
+
+## File Structure
+
+**Create:**
+- `tests/Feature/HostViewsTest.php` — view resolution + data contract
+- `tests/Feature/TableOfContentsTest.php` — parser, incl. the three cases the host regex got wrong
+- `tests/Fixtures/views/host-*.blade.php` — minimal host views that echo what they receive
+
+**Modify:**
+- `config/ink.php` — `views` map, `middleware`
+- `src/Http/Controllers/BlogController.php` — view resolution, preview payload, `tags` eager-load
+- `src/Models/Post.php` — `tableOfContents()`
+- `src/Ink.php` — `resolvePreviewEditUrlUsing()` / `resolvePreviewEditUrl()`
+- `routes/web.php` — configurable middleware, `whereNumber` on preview, conditional feed route
+- `README.md`, `UPGRADING.md`, `docs/content/2.essentials/*` — document the seams
+
+---
+
+### Task 1: Config keys and view resolution
+
+**Files:**
+- Modify: `config/ink.php`, `src/Http/Controllers/BlogController.php`
+- Create: `tests/Feature/HostViewsTest.php`, `tests/Fixtures/views/host-index.blade.php`, `tests/Fixtures/views/host-show.blade.php`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: config keys `ink.views.{index,show,category,tag,preview,feed}` (each `?string`) and `ink.middleware` (`array<string>`); `BlogController::viewFor(string $key): string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Fixtures/views/host-index.blade.php`:
+
+```blade
+HOST INDEX: {{ $posts->total() }} posts
+```
+
+Create `tests/Fixtures/views/host-show.blade.php`:
+
+```blade
+HOST SHOW: {{ $post->title }} / related={{ $relatedPosts->count() }} / tags={{ $post->tags->count() }}
+```
+
+Create `tests/Feature/HostViewsTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Relaticle\Ink\InkServiceProvider;
+use Relaticle\Ink\Models\Post;
+
+beforeEach(function () {
+    config()->set('ink.features.public_routes', true);
+    config()->set('ink.layout', 'tests::layouts.empty');
+
+    $this->app->register(InkServiceProvider::class, force: true);
+    $this->app->getProvider(InkServiceProvider::class)->packageBooted();
+    Route::getRoutes()->refreshNameLookups();
+});
+
+test('it renders ink pages when no host view is configured', function () {
+    Post::factory()->published()->create(['title' => 'Default rendering']);
+
+    $this->get(route('blog.index'))
+        ->assertOk()
+        ->assertDontSee('HOST INDEX');
+});
+
+test('it renders the host view for the index when configured', function () {
+    config()->set('ink.views.index', 'tests::host-index');
+    Post::factory(2)->published()->create();
+
+    $this->get(route('blog.index'))
+        ->assertOk()
+        ->assertSee('HOST INDEX: 2 posts');
+});
+
+test('it renders the host view for a post when configured', function () {
+    config()->set('ink.views.show', 'tests::host-show');
+    $post = Post::factory()->published()->create(['title' => 'Hello host', 'slug' => 'hello-host']);
+
+    $this->get(route('blog.show', 'hello-host'))
+        ->assertOk()
+        ->assertSee('HOST SHOW: Hello host');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/pest tests/Feature/HostViewsTest.php`
+Expected: the two "host view" tests FAIL — ink renders `ink::pages.*` regardless of config.
+
+- [ ] **Step 3: Add the config keys**
+
+In `config/ink.php`, add two top-level blocks after `'layout'`:
+
+```php
+    /*
+     * Render your own views instead of the package's. Each null falls back to
+     * the matching `ink::pages.*` view.
+     */
+    'views' => [
+        'index' => null,
+        'show' => null,
+        'category' => null,
+        'tag' => null,
+        'preview' => null,
+        'feed' => null,
+    ],
+
+    'middleware' => ['web'],
+```
+
+- [ ] **Step 4: Resolve views through config**
+
+In `src/Http/Controllers/BlogController.php`, add a private helper at the end of the class:
+
+```php
+    private function viewFor(string $key): string
+    {
+        $view = config("ink.views.{$key}");
+
+        return is_string($view) && $view !== '' ? $view : "ink::pages.{$key}";
+    }
+```
+
+Then replace each hardcoded view name:
+
+- `view('ink::pages.index', [...])` → `view($this->viewFor('index'), [...])`
+- `view('ink::pages.show', [...])` → `view($this->viewFor('show'), [...])`
+- `view('ink::pages.category', [...])` → `view($this->viewFor('category'), [...])`
+- `view('ink::pages.tag', [...])` → `view($this->viewFor('tag'), [...])`
+- `view('ink::pages.preview', [...])` → `view($this->viewFor('preview'), [...])`
+- `response()->view('ink::pages.feed', [...])` → `response()->view($this->viewFor('feed'), [...])`
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `vendor/bin/pest tests/Feature/HostViewsTest.php`
+Expected: 3 passed. The show test still fails on `$post->tags` — that is Task 2.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add config/ink.php src/Http/Controllers/BlogController.php tests/
+git commit -m "feat: let a host render its own views through ink's controllers"
+```
+
+---
+
+### Task 2: Preview payload, edit-URL hook and eager-loaded tags
+
+**Files:**
+- Modify: `src/Ink.php`, `src/Http/Controllers/BlogController.php`
+- Create: `tests/Fixtures/views/host-preview.blade.php`
+- Test: `tests/Feature/HostViewsTest.php` (append)
+
+**Interfaces:**
+- Consumes: `viewFor()` (Task 1)
+- Produces:
+  - `Ink::resolvePreviewEditUrlUsing(?Closure $callback): void`
+  - `Ink::resolvePreviewEditUrl(Post $post): ?string`
+  - `preview` view receives `post`, `relatedPosts`, `editUrl`
+  - `show` and `preview` eager-load `tags`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Fixtures/views/host-preview.blade.php`:
+
+```blade
+HOST PREVIEW: {{ $post->title }} / related={{ $relatedPosts->count() }} / edit={{ $editUrl ?? 'none' }}
+```
+
+Append to `tests/Feature/HostViewsTest.php`:
+
+```php
+test('the preview view receives related posts and a null edit url by default', function () {
+    config()->set('ink.views.preview', 'tests::host-preview');
+    $post = Post::factory()->create(['title' => 'Draft one']);
+
+    $this->get(URL::temporarySignedRoute('blog.preview', now()->addHour(), ['post' => $post]))
+        ->assertOk()
+        ->assertSee('HOST PREVIEW: Draft one')
+        ->assertSee('edit=none');
+});
+
+test('a host hook supplies the preview edit url', function () {
+    config()->set('ink.views.preview', 'tests::host-preview');
+    Ink::resolvePreviewEditUrlUsing(fn (Post $post): string => "https://admin.test/posts/{$post->id}/edit");
+
+    $post = Post::factory()->create(['title' => 'Draft two']);
+
+    $this->get(URL::temporarySignedRoute('blog.preview', now()->addHour(), ['post' => $post]))
+        ->assertOk()
+        ->assertSee("edit=https://admin.test/posts/{$post->id}/edit");
+});
+
+test('show and preview do not lazy-load tags', function () {
+    config()->set('ink.views.show', 'tests::host-show');
+    Model::preventLazyLoading();
+
+    $post = Post::factory()->published()->create(['slug' => 'no-lazy']);
+    $post->tags()->attach(Tag::factory()->create());
+
+    $this->get(route('blog.show', 'no-lazy'))->assertOk();
+
+    Model::preventLazyLoading(false);
+});
+```
+
+Add these imports at the top of the file:
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\URL;
+use Relaticle\Ink\Ink;
+use Relaticle\Ink\Models\Tag;
+```
+
+and reset the hook between tests by appending to the existing `beforeEach`:
+
+```php
+    Ink::flushState();
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/pest tests/Feature/HostViewsTest.php`
+Expected: FAIL — `Ink::resolvePreviewEditUrlUsing()` does not exist, and `$relatedPosts`/`$editUrl` are undefined in the preview view.
+
+- [ ] **Step 3: Add the hook to the Ink manager**
+
+In `src/Ink.php`, add a second property and two methods, and extend `flushState()`:
+
+```php
+    private static ?Closure $previewEditUrlResolver = null;
+
+    /**
+     * Register how to build the "edit this post" link shown on the preview page.
+     *
+     * Which panel and which guard own the blog admin is a host decision — a package
+     * that hardcodes it breaks the moment the host moves the resource.
+     */
+    public static function resolvePreviewEditUrlUsing(?Closure $callback): void
+    {
+        self::$previewEditUrlResolver = $callback;
+    }
+
+    public static function resolvePreviewEditUrl(Post $post): ?string
+    {
+        if (! self::$previewEditUrlResolver instanceof Closure) {
+            return null;
+        }
+
+        $url = (self::$previewEditUrlResolver)($post);
+
+        return is_string($url) && $url !== '' ? $url : null;
+    }
+```
+
+Add `use Relaticle\Ink\Models\Post;` to the imports, and inside `flushState()` add:
+
+```php
+        self::$previewEditUrlResolver = null;
+```
+
+- [ ] **Step 4: Enrich the controller's preview and show actions**
+
+In `src/Http/Controllers/BlogController.php`, add `use Relaticle\Ink\Ink;` to the imports.
+
+Change `show()`'s eager-load from `->with(['category', 'author', 'seo'])` to:
+
+```php
+            ->with(['category', 'author', 'seo', 'tags'])
+```
+
+Replace the body of `preview()` with:
+
+```php
+    public function preview(Post $post): View
+    {
+        $post->loadMissing(['category', 'author', 'seo', 'tags']);
+
+        $relatedPosts = $post->relatedPosts(limit: 3)->get();
+
+        seo()->for($post);
+
+        return view($this->viewFor('preview'), [
+            'post' => $post,
+            'relatedPosts' => $relatedPosts,
+            'editUrl' => Ink::resolvePreviewEditUrl($post),
+        ]);
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `vendor/bin/pest tests/Feature/HostViewsTest.php`
+Expected: 6 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Ink.php src/Http/Controllers/BlogController.php tests/
+git commit -m "feat: give the preview view related posts and a host-supplied edit url"
+```
+
+---
+
+### Task 3: Route middleware, numeric preview ids, conditional feed
+
+**Files:**
+- Modify: `routes/web.php`, `src/Http/Controllers/BlogController.php`
+- Create: `tests/Feature/BlogRouteConfigTest.php`
+
+**Interfaces:**
+- Consumes: `ink.middleware` (Task 1)
+- Produces: the blog route group uses configured middleware; `blog.preview` matches digits only; `blog.feed` exists only when `ink.features.feed` is true.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Feature/BlogRouteConfigTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Relaticle\Ink\InkServiceProvider;
+
+function bootBlogRoutes(array $config = []): void
+{
+    config()->set('ink.features.public_routes', true);
+    config()->set('ink.layout', 'tests::layouts.empty');
+
+    foreach ($config as $key => $value) {
+        config()->set($key, $value);
+    }
+
+    test()->app->register(InkServiceProvider::class, force: true);
+    test()->app->getProvider(InkServiceProvider::class)->packageBooted();
+    Route::getRoutes()->refreshNameLookups();
+}
+
+test('a non-numeric preview segment does not reach route model binding', function () {
+    bootBlogRoutes();
+
+    // Without whereNumber this casts to bigint and throws a QueryException — a 500
+    // on a public, unauthenticated route.
+    $this->get('/blog/preview/not-a-post-id')->assertNotFound();
+});
+
+test('the feed route is absent when the feature is off', function () {
+    bootBlogRoutes(['ink.features.feed' => false]);
+
+    expect(Route::has('blog.feed'))->toBeFalse();
+});
+
+test('the feed route is present when the feature is on', function () {
+    bootBlogRoutes(['ink.features.feed' => true]);
+
+    expect(Route::has('blog.feed'))->toBeTrue();
+});
+
+test('configured middleware is applied to the blog routes', function () {
+    bootBlogRoutes(['ink.middleware' => ['web', 'throttle:7,1']]);
+
+    $middleware = Route::getRoutes()->getByName('blog.index')->gatherMiddleware();
+
+    expect($middleware)->toContain('throttle:7,1');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/pest tests/Feature/BlogRouteConfigTest.php`
+Expected: FAIL — the preview route 500s, the feed route exists regardless of the flag, and the middleware is hardcoded.
+
+- [ ] **Step 3: Rewrite the route file**
+
+Replace `routes/web.php` with:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Relaticle\Ink\Http\Controllers\BlogController;
+
+$prefix = config('ink.prefix', 'ink');
+$middleware = config('ink.middleware', ['web']);
+
+Route::prefix($prefix)->middleware($middleware)->group(function (): void {
+    Route::get('/', [BlogController::class, 'index'])->name('blog.index');
+
+    // The tag route stays unconditional: TagsTest resolves route('blog.tag', ...) with the
+    // feature OFF, which would throw RouteNotFoundException if the route disappeared. The
+    // runtime abort_unless in tag() remains the gate.
+    Route::get('/tag/{slug}', [BlogController::class, 'tag'])->name('blog.tag');
+
+    Route::get('/category/{slug}', [BlogController::class, 'category'])->name('blog.category');
+
+    // whereNumber matters: {post} binds by id, so a non-numeric segment would otherwise
+    // reach the database and throw, 500ing a public route.
+    Route::get('/preview/{post}', [BlogController::class, 'preview'])
+        ->middleware('signed')
+        ->whereNumber('post')
+        ->name('blog.preview');
+
+    if (config('ink.features.feed', false)) {
+        Route::get('/feed', [BlogController::class, 'feed'])->name('blog.feed');
+    }
+
+    Route::get('/{slug}', [BlogController::class, 'show'])->name('blog.show');
+});
+```
+
+Note the feed route must be declared **before** the catch-all `/{slug}` route, and the tag route keeps its existing position.
+
+- [ ] **Step 4: Drop the now-redundant feed abort**
+
+In `src/Http/Controllers/BlogController.php`, delete this line from `feed()` — a disabled feed no longer has a route to reach:
+
+```php
+        abort_unless(config('ink.features.feed', false), 404);
+```
+
+Leave `tag()`'s `abort_unless` in place. Its route is still registered unconditionally, so the runtime check is what returns the 404.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `vendor/bin/pest tests/Feature/BlogRouteConfigTest.php`
+Expected: 4 passed.
+
+- [ ] **Step 6: Confirm nothing regressed**
+
+Run: `vendor/bin/pest && vendor/bin/pint --test`
+Expected: all pass. `TagsTest` must be untouched — it resolves `route('blog.tag', ...)` with the feature off, which is why that route stays registered.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add routes/web.php src/Http/Controllers/BlogController.php tests/
+git commit -m "feat: configurable blog route middleware, numeric preview ids, gated feed route"
+```
+
+---
+
+### Task 4: `Post::tableOfContents()`
+
+**Files:**
+- Modify: `src/Models/Post.php`
+- Create: `tests/Feature/TableOfContentsTest.php`
+
+**Interfaces:**
+- Consumes: `Post::toHtml()`
+- Produces: `Post::tableOfContents(string $tag = 'h2'): array<string, string>` — fragment => heading text.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Feature/TableOfContentsTest.php`. These are the exact cases a host-side regex got wrong, ported up as the regression lock:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\Ink\Models\Post;
+
+test('it keeps the full label when a heading contains inline markup', function () {
+    $post = Post::factory()->create([
+        'content' => "## Why **we** built it\n\nBody.\n\n## Using `artisan` commands\n\nBody.",
+    ]);
+
+    expect(array_values($post->tableOfContents()))
+        ->toBe(['Why we built it', 'Using artisan commands']);
+});
+
+test('it decodes entities exactly once', function () {
+    $post = Post::factory()->create(['content' => "## Ampersands & more\n\nBody."]);
+
+    expect(array_values($post->tableOfContents()))->toBe(['Ampersands & more']);
+});
+
+test('it keys entries by the permalink anchor id', function () {
+    $post = Post::factory()->create(['content' => "## Why we built it\n\nBody."]);
+
+    expect(array_keys($post->tableOfContents()))->toBe(['why-we-built-it']);
+});
+
+test('it returns an empty array for a post with no headings', function () {
+    $post = Post::factory()->create(['content' => 'Just a paragraph.']);
+
+    expect($post->tableOfContents())->toBe([]);
+});
+
+test('it strips the injected permalink symbol from the label', function () {
+    $post = Post::factory()->create(['content' => "## Plain heading\n\nBody."]);
+
+    expect(array_values($post->tableOfContents()))->toBe(['Plain heading']);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/pest tests/Feature/TableOfContentsTest.php`
+Expected: FAIL — `Call to undefined method ...::tableOfContents()`.
+
+- [ ] **Step 3: Implement it on the model**
+
+In `src/Models/Post.php`, add these imports:
+
+```php
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+```
+
+and add this method directly after `toHtml()`:
+
+```php
+    /**
+     * Build a fragment => heading-text map from the rendered post.
+     *
+     * DOM-parsed rather than regex: heading text is taken from textContent so inline
+     * markup (bold, code, links) survives, and entities decode exactly once. The
+     * fragment comes from the injected permalink anchor — the heading's own id is
+     * slugified from its inner HTML and unusable as a target.
+     *
+     * @return array<string, string>
+     */
+    public function tableOfContents(string $tag = 'h2'): array
+    {
+        $html = $this->toHtml();
+
+        if (trim($html) === '') {
+            return [];
+        }
+
+        $document = new DOMDocument;
+
+        $previous = libxml_use_internal_errors(true);
+        $document->loadHTML('<?xml encoding="UTF-8"?><div>'.$html.'</div>', LIBXML_NOWARNING | LIBXML_NOERROR);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        $toc = [];
+
+        foreach (new DOMXPath($document)->query('//'.$tag) ?: [] as $heading) {
+            if (! $heading instanceof DOMElement) {
+                continue;
+            }
+
+            $fragment = $this->headingFragment($heading);
+            $text = $this->headingText($heading);
+
+            if ($fragment === null || $text === '') {
+                continue;
+            }
+
+            $toc[$fragment] = $text;
+        }
+
+        return $toc;
+    }
+
+    private function headingFragment(DOMElement $heading): ?string
+    {
+        foreach ($heading->getElementsByTagName('a') as $anchor) {
+            $id = $anchor->getAttribute('id');
+
+            if ($id !== '') {
+                return $id;
+            }
+        }
+
+        $ownId = $heading->getAttribute('id');
+
+        return $ownId === '' ? null : $ownId;
+    }
+
+    private function headingText(DOMElement $heading): string
+    {
+        $clone = $heading->cloneNode(true);
+
+        if (! $clone instanceof DOMElement) {
+            return '';
+        }
+
+        foreach (iterator_to_array($clone->getElementsByTagName('a')) as $anchor) {
+            if ($anchor->getAttribute('id') !== '') {
+                $anchor->parentNode?->removeChild($anchor);
+            }
+        }
+
+        return trim(preg_replace('/\s+/u', ' ', $clone->textContent) ?? '');
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/pest tests/Feature/TableOfContentsTest.php`
+Expected: 5 passed.
+
+If the fragment test fails, the test host is not configuring heading permalinks. Set the same
+`markdown.commonmark_options.heading_permalink` block the docs use in
+`TestCase::defineEnvironment()` — the parser depends on that extension being enabled, and
+that dependency should be explicit in the test host rather than assumed.
+
+- [ ] **Step 5: Confirm the whole suite is green**
+
+Run: `vendor/bin/pest && vendor/bin/pint --test`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Models/Post.php tests/Feature/TableOfContentsTest.php
+git commit -m "feat: add Post::tableOfContents()"
+```
+
+---
+
+### Task 5: Documentation and release
+
+**Files:**
+- Modify: `README.md`, `UPGRADING.md`, `docs/content/2.essentials/`
+
+**Interfaces:**
+- Consumes: everything above
+- Produces: no code.
+
+- [ ] **Step 1: Document the seams**
+
+Add a "Using your own views" section to the docs covering: the `views` config map with the
+fallback rule, the per-action data contract table from the spec, `ink.middleware`, and
+`Ink::resolvePreviewEditUrlUsing()` with the Relaticle example:
+
+```php
+Ink::resolvePreviewEditUrlUsing(fn (Post $post): ?string =>
+    auth('sysadmin')->check()
+        ? PostResource::getUrl('edit', ['record' => $post], panel: 'sysadmin')
+        : null);
+```
+
+State plainly that publishing views is **not** the recommended route — a published file is a
+frozen copy that stops receiving upstream changes — and that pointing ink at host-owned views
+avoids both drift and surprise.
+
+- [ ] **Step 2: Document `tableOfContents()`**
+
+Add it to the docs' post-model reference with a short example building a TOC in a host view.
+
+- [ ] **Step 3: Warn about the shallow config merge**
+
+Add a note to the docs: `mergeConfigFrom` is shallow, so a host that has published
+`config/ink.php` will not receive new keys added *inside* an existing array such as
+`features` — those must be added by hand. New top-level keys merge normally.
+
+- [ ] **Step 4: Write the upgrade notes**
+
+Append a `## To 2.3 from 2.2` section to `UPGRADING.md`: the `views`/`middleware` config keys
+are additive; `feed()` and `tag()` no longer abort at runtime because their routes are now
+conditional; `preview` gains `relatedPosts` and `editUrl` in its view data.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs README.md UPGRADING.md
+git commit -m "docs: document host-owned views, the preview hook and tableOfContents"
+```
+
+---
+
+## Verification
+
+- [ ] `vendor/bin/pest` — all pass, including the 3 new files
+- [ ] `vendor/bin/pint --test` — clean
+- [ ] `grep -rn "ink::pages\." src/Http/Controllers/BlogController.php` — no output (all resolved through `viewFor`)
+- [ ] `grep -c "abort_unless" src/Http/Controllers/BlogController.php` — exactly 1 (tag only)
+- [ ] CI green on `2.x`, then tag **v2.3.0**
+
+## Relaticle follow-up (separate branch, after v2.3.0 is tagged)
+
+1. `composer update relaticle/ink`
+2. Delete `app/Http/Controllers/BlogController.php`, `app/Http/Controllers/Blog/*` (5 files), `app/Support/Blog/TableOfContents.php`, and the blog route group in `routes/web.php`.
+3. In `config/ink.php` set `features.public_routes`, `features.feed` and `features.tags` to true; add `'middleware' => ['web', ProvideMarkdownResponse::class]`; add the `views` map pointing at `blog.index`, `blog.show`, `blog.index` (category), `blog.index` (tag), `blog.preview`, `blog.feed`.
+4. Register `Ink::resolvePreviewEditUrlUsing()` in `AppServiceProvider::boot()`.
+5. Change `x-blog.toc` to call `$post->tableOfContents()`.
+6. **The existing `tests/Feature/Public/PublicPagesTest.php` must pass unchanged** — that is the proof the rendered design is identical. Any assertion needing a change means behaviour drifted; investigate rather than edit the assertion.

--- a/docs/superpowers/specs/2026-08-06-host-owned-views-design.md
+++ b/docs/superpowers/specs/2026-08-06-host-owned-views-design.md
@@ -1,0 +1,200 @@
+# Host-owned views: let a host use ink's controllers with its own markup
+
+**Date:** 2026-08-06
+**Status:** approved, pending implementation plan
+**Branch:** `2.x` → target release `v2.3.0`
+
+## Problem
+
+Ink ships a `BlogController` with all six public actions, behind `features.public_routes`.
+Relaticle could not use it, so it reimplemented all six as five app controllers plus its own
+route group — about 150 lines duplicating the package — and set `public_routes => false`.
+
+The cause is not the controller. It is the **layout seam**. Ink's pages open with:
+
+```blade
+@extends(config('ink.layout', 'layouts.app'))
+```
+
+Blade *inheritance*. Relaticle's layout is a *component* taking props:
+
+```blade
+<x-guest-layout :title="..." :description="..." :ogImage="...">
+```
+
+`@extends` cannot pass props to a component, so Relaticle could not render its chrome from
+ink's pages. It wrote its own views, and then needed its own controllers to render them.
+The controllers are a symptom.
+
+### What the fork costs
+
+Ink's controller does three things the copies do not:
+
+- **Listing SEO** — every listing action calls `seo()->for(BlogListingSeo::forIndex(page: ...))`,
+  which emits a **page-aware canonical** (`$url = $page > 1 ? "{$base}?page={$page}" : $base`).
+  That is exactly the open finding "paginated pages canonicalise to page 1, so posts that
+  exist only on page 2 have no canonical listing page". Ink already solves it; the copies
+  never call it.
+- **Search** — `?q=` through the `search()` scope, wired to the `blog::search` Livewire
+  component ink also ships.
+- **`withQueryString()`** on the paginator, so filters survive pagination.
+
+`seo()->for($post)` on show is missing from the copy too.
+
+## Goals
+
+1. A host renders **its own views** through ink's controllers, publishing nothing.
+2. Relaticle deletes its five controllers and route group, and its design is unchanged.
+3. The route-level behaviour Relaticle added (markdown responses, numeric preview ids) is
+   expressible in ink rather than lost.
+
+## Non-goals
+
+- Making ink's own markup match any host's design. Hosts that want bespoke markup supply
+  their own views; ink's pages remain the zero-config default.
+- Publishing views as the customisation route. Laravel resolves
+  `resources/views/vendor/ink/**` ahead of `ink::**` automatically, so it *works* — but a
+  published file is a frozen copy of package markup that silently stops receiving upstream
+  changes. Two incidents in this codebase already: a `structured-data` override that had to
+  be retired by hand once upstream caught up, and FilaForms rendering `ink::pages.*` where a
+  package change would have blanked three posts. Publish and you drift; don't publish and
+  upstream surprises you. Pointing ink at host-owned views avoids both.
+- Moving `App\Support\Blog\TableOfContents` upstream. It is a clean reusable parser and
+  could later become `$post->tableOfContents()`, but it is not needed to drop the
+  controllers, and its markup is host design.
+
+## Design
+
+### View resolution
+
+A config map of plain strings — cacheable, no closures, the Spatie lever used by
+`media_model` / `path_generator` / `renderer_class`:
+
+```php
+// config/ink.php
+'views' => [
+    'index' => null,
+    'show' => null,
+    'category' => null,
+    'tag' => null,
+    'preview' => null,
+    'feed' => null,
+],
+```
+
+`null` falls back to the current `ink::pages.*`, so existing hosts are unaffected. The
+controller resolves through one helper:
+
+```php
+private function view(string $key): string
+{
+    return config("ink.views.{$key}") ?? "ink::pages.{$key}";
+}
+```
+
+Fortify's callback style (`Fortify::loginView(...)`) was considered and rejected: it exists
+so a host can return an Inertia or Livewire *response*, which no ink action needs. A view
+name carries everything, and stays `config:cache`-safe.
+
+### View data contract
+
+Ink already passes what host views need, with two gaps:
+
+| action | passes today | change |
+|---|---|---|
+| `index` | `posts` | — |
+| `show` | `post`, `relatedPosts` | eager-load `tags` |
+| `category` | `category`, `posts` | — |
+| `tag` | `tag`, `posts` | — |
+| `preview` | `post` | add `relatedPosts`, add `editUrl` |
+| `feed` | `posts` | — |
+
+`show` currently loads `['category', 'author', 'seo']`; host views iterating `$post->tags`
+force a lazy load. Add `tags` to the eager-load on `show` and `preview`.
+
+### Preview edit URL
+
+Which panel and which guard own the blog admin is a host decision, and hardcoding it breaks:
+Relaticle moved its blog admin to the sysadmin panel and the app's preview controller kept
+building `filament.app.resources.posts.edit`, 500ing the page for every authenticated user
+while guests still saw 200. A provider-registered hook, same shape as
+`Ink::resolveAuthorUsing()`:
+
+```php
+Ink::resolvePreviewEditUrlUsing(fn (Post $post): ?string => ...);
+```
+
+Defaults to `null`; hosts wanting no edit link register nothing.
+
+### Route configuration
+
+```php
+'middleware' => ['web'],
+```
+
+Applied to the route group, replacing the hardcoded `web`. Relaticle appends
+`ProvideMarkdownResponse`.
+
+The preview route gains `->whereNumber('post')`. Without it a non-numeric segment reaches
+route-model binding and throws a `QueryException` — an unauthenticated 500 on a public
+route, which Relaticle already had to patch app-side.
+
+### Feed gating
+
+`feed()` currently runs `abort_unless(config('ink.features.feed'), 404)` while the route is
+registered unconditionally. Register the route only when the flag is on and drop the runtime
+abort — a disabled feature should not have a route at all, matching how `public_routes` and
+`mcp` already behave.
+
+## Relaticle's migration
+
+Delete `app/Http/Controllers/BlogController.php`, `app/Http/Controllers/Blog/*` (5 files) and
+the blog route group in `routes/web.php`. Set in `config/ink.php`:
+
+```php
+'features' => ['public_routes' => true, 'feed' => true, 'tags' => true],
+'middleware' => ['web', ProvideMarkdownResponse::class],
+'views' => [
+    'index' => 'blog.index',
+    'show' => 'blog.show',
+    'category' => 'blog.index',
+    'tag' => 'blog.index',
+    'preview' => 'blog.preview',
+    'feed' => 'blog.feed',
+],
+```
+
+and register the edit-URL hook in `AppServiceProvider::boot()`.
+
+Kept unchanged: all six blog views, `blog/pagination.blade.php`, `x-blog.toc`, and
+`App\Support\Blog\TableOfContents`. The rendered design is identical.
+
+Gained: the page-aware canonical, `seo()->for($post)` on show, `?q=` search, and
+`withQueryString()`.
+
+**Note on the `features` array.** Relaticle publishes `config/ink.php`, and
+`mergeConfigFrom` is a *shallow* merge — the host's `features` array replaces the package's
+wholesale, so keys added upstream inside `features` never reach a host that has published
+the file. `ink.features.mcp` currently resolves to `NULL` in Relaticle for exactly this
+reason. Any new top-level key (`views`, `middleware`) merges fine; anything added *inside*
+`features` must be added to the host config by hand. Document this.
+
+## Testing
+
+1. **View resolution** — each action renders the configured view when set, and `ink::pages.*`
+   when null.
+2. **Data contract** — `preview` receives `relatedPosts` and `editUrl`; `show` and `preview`
+   do not lazy-load `tags`.
+3. **Edit-URL hook** — default null; a registered hook is used; the hook receives the post.
+4. **Route config** — configured middleware is applied; `/blog/preview/not-a-number` returns
+   404, not 500.
+5. **Feed gating** — no feed route when `features.feed` is off; 200 when on.
+
+On the Relaticle side, the existing public-pages suite is the regression lock: it must pass
+unchanged after the controllers are deleted, proving the rendered output is identical.
+
+## Breaking changes
+
+None for hosts on ink's own views. `feed()` no longer aborts at runtime — a host relying on
+the route existing while the flag is off would now 404 at routing time instead, which is the
+intended behaviour.

--- a/docs/superpowers/specs/2026-08-06-host-owned-views-design.md
+++ b/docs/superpowers/specs/2026-08-06-host-owned-views-design.md
@@ -59,9 +59,8 @@ Ink's controller does three things the copies do not:
   be retired by hand once upstream caught up, and FilaForms rendering `ink::pages.*` where a
   package change would have blanked three posts. Publish and you drift; don't publish and
   upstream surprises you. Pointing ink at host-owned views avoids both.
-- Moving `App\Support\Blog\TableOfContents` upstream. It is a clean reusable parser and
-  could later become `$post->tableOfContents()`, but it is not needed to drop the
-  controllers, and its markup is host design.
+- Styling the table of contents. The *markup* stays host design; only the parser moves
+  upstream (below).
 
 ## Design
 
@@ -126,6 +125,26 @@ Ink::resolvePreviewEditUrlUsing(fn (Post $post): ?string => ...);
 
 Defaults to `null`; hosts wanting no edit link register nothing.
 
+### Table of contents
+
+`Post::tableOfContents(string $tag = 'h2'): array` returning `fragment => heading text`.
+
+This belongs in ink, not the host. The parser reads the output of `Post::toHtml()` — ink's
+own method — so a host implementing it is reverse-engineering package output. That is the
+same fragility this spec removes elsewhere, and it has already failed once: Relaticle's
+original regex-based extractor cut every heading at the first inline tag, so
+`## Using \`artisan\` commands` rendered as "Using", and double-escaped entities so
+`& chars` appeared as `&amp;`. It was guessing at ink's HTML shape and guessing wrong, while
+ink's rendering changed twice in the same week.
+
+Implementation is DOM-based, not regex: parse `toHtml()`, take each heading's `textContent`
+so inline markup (bold, code, links) survives, prefer the permalink anchor's `id` for the
+fragment — the heading's own `id` is slugified from its inner HTML and unusable — and strip
+the injected `#` anchor from the label.
+
+Hosts keep their own TOC markup and call `$post->tableOfContents()` to build it. Ink's own
+`pages/show` does not render one; adding that is out of scope.
+
 ### Route configuration
 
 ```php
@@ -166,8 +185,11 @@ the blog route group in `routes/web.php`. Set in `config/ink.php`:
 
 and register the edit-URL hook in `AppServiceProvider::boot()`.
 
-Kept unchanged: all six blog views, `blog/pagination.blade.php`, `x-blog.toc`, and
-`App\Support\Blog\TableOfContents`. The rendered design is identical.
+Also delete `app/Support/Blog/TableOfContents.php` (96 lines) and change `x-blog.toc` to
+call `$post->tableOfContents()`.
+
+Kept unchanged: all six blog views, `blog/pagination.blade.php` and the `x-blog.toc` markup.
+The rendered design is identical.
 
 Gained: the page-aware canonical, `seo()->for($post)` on show, `?q=` search, and
 `withQueryString()`.
@@ -189,6 +211,10 @@ reason. Any new top-level key (`views`, `middleware`) merges fine; anything adde
 4. **Route config** — configured middleware is applied; `/blog/preview/not-a-number` returns
    404, not 500.
 5. **Feed gating** — no feed route when `features.feed` is off; 200 when on.
+6. **Table of contents** — a heading containing bold, inline code and an entity keeps its
+   full label and single-escapes; the fragment matches the permalink anchor's `id`; a post
+   with no headings returns an empty array. These are the exact cases the host-side regex
+   got wrong, ported up as the regression lock.
 
 On the Relaticle side, the existing public-pages suite is the regression lock: it must pass
 unchanged after the controllers are deleted, proving the rendered output is identical.

--- a/resources/views/pages/preview.blade.php
+++ b/resources/views/pages/preview.blade.php
@@ -1,6 +1,7 @@
 @extends(config('ink.layout', 'layouts.app'))
 
 @section('content')
+<meta name="robots" content="noindex, nofollow">
 <x-ink::preview-banner :post="$post" :editUrl="$editUrl" />
 <article class="max-w-2xl mx-auto px-4 py-12 prose dark:prose-invert">
     <h1>{{ $post->title }}</h1>

--- a/resources/views/pages/preview.blade.php
+++ b/resources/views/pages/preview.blade.php
@@ -1,11 +1,8 @@
 @extends(config('ink.layout', 'layouts.app'))
 
 @section('content')
-<meta name="robots" content="noindex, nofollow">
+<x-ink::preview-banner :post="$post" :editUrl="$editUrl" />
 <article class="max-w-2xl mx-auto px-4 py-12 prose dark:prose-invert">
-    <div class="bg-yellow-50 border-l-4 border-yellow-400 p-3 mb-6 text-sm">
-        Preview mode — this draft is not publicly visible.
-    </div>
     <h1>{{ $post->title }}</h1>
     <div class="post-body">
         {!! \Illuminate\Support\Str::markdown($post->content ?? '', ['html_input' => 'strip', 'allow_unsafe_links' => false]) !!}

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,11 +18,14 @@ Route::prefix($prefix)->middleware($middleware)->group(function (): void {
 
     Route::get('/category/{slug}', [BlogController::class, 'category'])->name('blog.category');
 
-    // whereNumber matters: {post} binds by id, so a non-numeric segment would otherwise
-    // reach the database and throw, 500ing a public route.
+    // The constraint matters: {post} binds by id, so a non-numeric segment would
+    // otherwise reach the database and throw, 500ing a public route. It's bounded to
+    // 18 digits (safe max for a signed 64-bit id) rather than whereNumber()'s unbounded
+    // [0-9]+, which would let an arbitrarily long digit string reach the query and
+    // overflow a bigint column on Postgres.
     Route::get('/preview/{post}', [BlogController::class, 'preview'])
         ->middleware('signed')
-        ->whereNumber('post')
+        ->where('post', '[0-9]{1,18}')
         ->name('blog.preview');
 
     if (config('ink.features.feed', false)) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,14 +6,28 @@ use Illuminate\Support\Facades\Route;
 use Relaticle\Ink\Http\Controllers\BlogController;
 
 $prefix = config('ink.prefix', 'ink');
+$middleware = config('ink.middleware', ['web']);
 
-Route::prefix($prefix)->middleware('web')->group(function () {
+Route::prefix($prefix)->middleware($middleware)->group(function (): void {
     Route::get('/', [BlogController::class, 'index'])->name('blog.index');
+
+    // The tag route stays unconditional: TagsTest resolves route('blog.tag', ...) with the
+    // feature OFF, which would throw RouteNotFoundException if the route disappeared. The
+    // runtime abort_unless in tag() remains the gate.
     Route::get('/tag/{slug}', [BlogController::class, 'tag'])->name('blog.tag');
+
     Route::get('/category/{slug}', [BlogController::class, 'category'])->name('blog.category');
+
+    // whereNumber matters: {post} binds by id, so a non-numeric segment would otherwise
+    // reach the database and throw, 500ing a public route.
     Route::get('/preview/{post}', [BlogController::class, 'preview'])
         ->middleware('signed')
+        ->whereNumber('post')
         ->name('blog.preview');
-    Route::get('/feed', [BlogController::class, 'feed'])->name('blog.feed');
+
+    if (config('ink.features.feed', false)) {
+        Route::get('/feed', [BlogController::class, 'feed'])->name('blog.feed');
+    }
+
     Route::get('/{slug}', [BlogController::class, 'show'])->name('blog.show');
 });

--- a/src/Http/Controllers/BlogController.php
+++ b/src/Http/Controllers/BlogController.php
@@ -39,7 +39,7 @@ class BlogController extends Controller
             searchQuery: $request->query('q'),
         ));
 
-        return view('ink::pages.index', [
+        return view($this->viewFor('index'), [
             'posts' => $posts,
         ]);
     }
@@ -56,7 +56,7 @@ class BlogController extends Controller
 
         seo()->for($post);
 
-        return view('ink::pages.show', [
+        return view($this->viewFor('show'), [
             'post' => $post,
             'relatedPosts' => $relatedPosts,
         ]);
@@ -79,7 +79,7 @@ class BlogController extends Controller
             page: (int) request()->query('page', 1),
         ));
 
-        return view('ink::pages.category', [
+        return view($this->viewFor('category'), [
             'category' => $category,
             'posts' => $posts,
         ]);
@@ -91,7 +91,7 @@ class BlogController extends Controller
 
         seo()->for($post);
 
-        return view('ink::pages.preview', [
+        return view($this->viewFor('preview'), [
             'post' => $post,
         ]);
     }
@@ -115,7 +115,7 @@ class BlogController extends Controller
             page: (int) request()->query('page', 1),
         ));
 
-        return view('ink::pages.tag', [
+        return view($this->viewFor('tag'), [
             'tag' => $tag,
             'posts' => $posts,
         ]);
@@ -133,7 +133,14 @@ class BlogController extends Controller
             ->get();
 
         return response()
-            ->view('ink::pages.feed', ['posts' => $posts])
+            ->view($this->viewFor('feed'), ['posts' => $posts])
             ->header('Content-Type', 'application/rss+xml; charset=UTF-8');
+    }
+
+    private function viewFor(string $key): string
+    {
+        $view = config("ink.views.{$key}");
+
+        return is_string($view) && $view !== '' ? $view : "ink::pages.{$key}";
     }
 }

--- a/src/Http/Controllers/BlogController.php
+++ b/src/Http/Controllers/BlogController.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
+use Relaticle\Ink\Ink;
 use Relaticle\Ink\Models\Category;
 use Relaticle\Ink\Models\Post;
 use Relaticle\Ink\Models\Tag;
@@ -47,7 +48,7 @@ class BlogController extends Controller
     public function show(string $slug): View
     {
         $post = Post::query()
-            ->with(['category', 'author', 'seo'])
+            ->with(['category', 'author', 'seo', 'tags'])
             ->where('slug', $slug)
             ->published()
             ->firstOrFail();
@@ -87,12 +88,16 @@ class BlogController extends Controller
 
     public function preview(Post $post): View
     {
-        $post->loadMissing(['category', 'author', 'seo']);
+        $post->loadMissing(['category', 'author', 'seo', 'tags']);
+
+        $relatedPosts = $post->relatedPosts(limit: 3)->get();
 
         seo()->for($post);
 
         return view($this->viewFor('preview'), [
             'post' => $post,
+            'relatedPosts' => $relatedPosts,
+            'editUrl' => Ink::resolvePreviewEditUrl($post),
         ]);
     }
 

--- a/src/Http/Controllers/BlogController.php
+++ b/src/Http/Controllers/BlogController.php
@@ -128,8 +128,6 @@ class BlogController extends Controller
 
     public function feed(): Response
     {
-        abort_unless(config('ink.features.feed', false), 404);
-
         $posts = Post::query()
             ->with(['author', 'seo'])
             ->published()

--- a/src/Ink.php
+++ b/src/Ink.php
@@ -7,10 +7,13 @@ namespace Relaticle\Ink;
 use Closure;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
+use Relaticle\Ink\Models\Post;
 
 final class Ink
 {
     private static ?Closure $authorResolver = null;
+
+    private static ?Closure $previewEditUrlResolver = null;
 
     /**
      * Register how an MCP caller maps to the model that authors a post.
@@ -43,8 +46,31 @@ final class Ink
             : null;
     }
 
+    /**
+     * Register how to build the "edit this post" link shown on the preview page.
+     *
+     * Which panel and which guard own the blog admin is a host decision — a package
+     * that hardcodes it breaks the moment the host moves the resource.
+     */
+    public static function resolvePreviewEditUrlUsing(?Closure $callback): void
+    {
+        self::$previewEditUrlResolver = $callback;
+    }
+
+    public static function resolvePreviewEditUrl(Post $post): ?string
+    {
+        if (! self::$previewEditUrlResolver instanceof Closure) {
+            return null;
+        }
+
+        $url = (self::$previewEditUrlResolver)($post);
+
+        return is_string($url) && $url !== '' ? $url : null;
+    }
+
     public static function flushState(): void
     {
         self::$authorResolver = null;
+        self::$previewEditUrlResolver = null;
     }
 }

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Relaticle\Ink\Models;
 
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -168,6 +171,83 @@ class Post extends Model
             "post-rendered:{$this->id}",
             fn (): string => app(MarkdownRenderer::class)->toHtml($this->content),
         );
+    }
+
+    /**
+     * Build a fragment => heading-text map from the rendered post.
+     *
+     * DOM-parsed rather than regex: heading text is taken from textContent so inline
+     * markup (bold, code, links) survives, and entities decode exactly once. The
+     * fragment comes from the injected permalink anchor — the heading's own id is
+     * slugified from its inner HTML and unusable as a target.
+     *
+     * @return array<string, string>
+     */
+    public function tableOfContents(string $tag = 'h2'): array
+    {
+        $html = $this->toHtml();
+
+        if (trim($html) === '') {
+            return [];
+        }
+
+        $document = new DOMDocument;
+
+        $previous = libxml_use_internal_errors(true);
+        $document->loadHTML('<?xml encoding="UTF-8"?><div>'.$html.'</div>', LIBXML_NOWARNING | LIBXML_NOERROR);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        $toc = [];
+
+        foreach (new DOMXPath($document)->query('//'.$tag) ?: [] as $heading) {
+            if (! $heading instanceof DOMElement) {
+                continue;
+            }
+
+            $fragment = $this->headingFragment($heading);
+            $text = $this->headingText($heading);
+
+            if ($fragment === null || $text === '') {
+                continue;
+            }
+
+            $toc[$fragment] = $text;
+        }
+
+        return $toc;
+    }
+
+    private function headingFragment(DOMElement $heading): ?string
+    {
+        foreach ($heading->getElementsByTagName('a') as $anchor) {
+            $id = $anchor->getAttribute('id');
+
+            if ($id !== '') {
+                return $id;
+            }
+        }
+
+        $ownId = $heading->getAttribute('id');
+
+        return $ownId === '' ? null : $ownId;
+    }
+
+    private function headingText(DOMElement $heading): string
+    {
+        $clone = $heading->cloneNode(true);
+
+        if (! $clone instanceof DOMElement) {
+            return '';
+        }
+
+        foreach (iterator_to_array($clone->getElementsByTagName('a')) as $anchor) {
+            if ($anchor->getAttribute('id') !== '') {
+                $anchor->parentNode?->removeChild($anchor);
+            }
+        }
+
+        return trim(preg_replace('/\s+/u', ' ', $clone->textContent) ?? '');
     }
 
     public function readingTime(int $wordsPerMinute = 200): int

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -19,6 +19,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use RalphJSmit\Laravel\SEO\Schema\ArticleSchema;
 use RalphJSmit\Laravel\SEO\Schema\BreadcrumbListSchema;
 use RalphJSmit\Laravel\SEO\Schema\FaqPageSchema;
@@ -185,6 +186,12 @@ class Post extends Model
      */
     public function tableOfContents(string $tag = 'h2'): array
     {
+        if (! preg_match('/^h[1-6]$/', $tag)) {
+            throw new InvalidArgumentException(
+                "Invalid heading tag [{$tag}] passed to Post::tableOfContents(). Allowed values are h1, h2, h3, h4, h5, h6.",
+            );
+        }
+
         $html = $this->toHtml();
 
         if (trim($html) === '') {

--- a/tests/Feature/BlogRouteConfigTest.php
+++ b/tests/Feature/BlogRouteConfigTest.php
@@ -19,11 +19,20 @@ function bootBlogRoutes(array $config = []): void
     Route::getRoutes()->refreshNameLookups();
 }
 
-test('a non-numeric preview segment does not reach route model binding', function () {
+test('the preview route constrains the post segment to digits and rejects non-numeric segments', function () {
     bootBlogRoutes();
 
-    // Without whereNumber this casts to bigint and throws a QueryException — a 500
-    // on a public, unauthenticated route.
+    // The route-model-binding 404 below is engine-dependent: SQLite's loose type
+    // affinity makes `WHERE id = 'not-a-post-id'` against a bigint column return zero
+    // rows (ModelNotFoundException) whether or not the constraint is present, whereas
+    // Postgres would throw a QueryException without it. Assert on the compiled route's
+    // constraint directly so this test actually fails if whereNumber is removed.
+    $route = Route::getRoutes()->getByName('blog.preview');
+
+    expect($route->wheres)->toHaveKey('post')
+        ->and($route->wheres['post'])->toBe('[0-9]+');
+
+    // Also lock the user-visible contract: a non-numeric segment 404s, not 500s.
     $this->get('/blog/preview/not-a-post-id')->assertNotFound();
 });
 

--- a/tests/Feature/BlogRouteConfigTest.php
+++ b/tests/Feature/BlogRouteConfigTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Relaticle\Ink\InkServiceProvider;
 
@@ -26,14 +28,37 @@ test('the preview route constrains the post segment to digits and rejects non-nu
     // affinity makes `WHERE id = 'not-a-post-id'` against a bigint column return zero
     // rows (ModelNotFoundException) whether or not the constraint is present, whereas
     // Postgres would throw a QueryException without it. Assert on the compiled route's
-    // constraint directly so this test actually fails if whereNumber is removed.
+    // constraint directly so this test actually fails if the constraint is removed.
     $route = Route::getRoutes()->getByName('blog.preview');
 
     expect($route->wheres)->toHaveKey('post')
-        ->and($route->wheres['post'])->toBe('[0-9]+');
+        ->and($route->wheres['post'])->toBe('[0-9]{1,18}');
 
     // Also lock the user-visible contract: a non-numeric segment 404s, not 500s.
     $this->get('/blog/preview/not-a-post-id')->assertNotFound();
+});
+
+test('the preview route rejects an over-long digit segment before it reaches the database', function () {
+    bootBlogRoutes();
+
+    // whereNumber()'s unbounded [0-9]+ still matches this segment, so the route would
+    // match and route-model binding would query the database with it — on Postgres
+    // that overflows a bigint column (SQLSTATE[22003] Numeric value out of range), a
+    // public unauthenticated 500. SQLite happens to return zero rows instead of
+    // throwing, so an `assertNotFound()` alone can't tell the two constraints apart
+    // here — assert directly that no query for the post was even issued, which only
+    // happens when the router itself rejects the segment before binding runs.
+    $queries = collect();
+
+    DB::listen(function (QueryExecuted $query) use ($queries): void {
+        if (str_contains($query->sql, 'blog_posts')) {
+            $queries->push($query->sql);
+        }
+    });
+
+    $this->get('/blog/preview/9999999999999999999999999')->assertNotFound();
+
+    expect($queries)->toBeEmpty();
 });
 
 test('the feed route is absent when the feature is off', function () {

--- a/tests/Feature/BlogRouteConfigTest.php
+++ b/tests/Feature/BlogRouteConfigTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Relaticle\Ink\InkServiceProvider;
+
+function bootBlogRoutes(array $config = []): void
+{
+    config()->set('ink.features.public_routes', true);
+    config()->set('ink.layout', 'tests::layouts.empty');
+
+    foreach ($config as $key => $value) {
+        config()->set($key, $value);
+    }
+
+    app()->register(InkServiceProvider::class, force: true);
+    app()->getProvider(InkServiceProvider::class)->packageBooted();
+    Route::getRoutes()->refreshNameLookups();
+}
+
+test('a non-numeric preview segment does not reach route model binding', function () {
+    bootBlogRoutes();
+
+    // Without whereNumber this casts to bigint and throws a QueryException — a 500
+    // on a public, unauthenticated route.
+    $this->get('/blog/preview/not-a-post-id')->assertNotFound();
+});
+
+test('the feed route is absent when the feature is off', function () {
+    bootBlogRoutes(['ink.features.feed' => false]);
+
+    expect(Route::has('blog.feed'))->toBeFalse();
+});
+
+test('the feed route is present when the feature is on', function () {
+    bootBlogRoutes(['ink.features.feed' => true]);
+
+    expect(Route::has('blog.feed'))->toBeTrue();
+});
+
+test('configured middleware is applied to the blog routes', function () {
+    bootBlogRoutes(['ink.middleware' => ['web', 'throttle:7,1']]);
+
+    $middleware = Route::getRoutes()->getByName('blog.index')->gatherMiddleware();
+
+    expect($middleware)->toContain('throttle:7,1');
+});

--- a/tests/Feature/HostViewsTest.php
+++ b/tests/Feature/HostViewsTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Relaticle\Ink\Ink;
@@ -70,12 +72,43 @@ test('a host hook supplies the preview edit url', function () {
 
 test('show and preview do not lazy-load tags', function () {
     config()->set('ink.views.show', 'tests::host-show');
-    Model::preventLazyLoading();
+    config()->set('ink.views.preview', 'tests::host-preview');
 
     $post = Post::factory()->published()->create(['slug' => 'no-lazy']);
     $post->tags()->attach(Tag::factory()->create());
 
-    $this->get(route('blog.show', 'no-lazy'))->assertOk();
+    /**
+     * A single post fetched by slug/id is a single-row hydration, and Eloquent's
+     * `Model::preventLazyLoading()` guard only arms on multi-row hydration (see
+     * `Builder::hydrate()`), so it cannot catch a missing eager-load here. What
+     * *is* observable from outside the request is the query shape: eager-loading
+     * a BelongsToMany always issues a `whereIn` constraint (`addEagerConstraints`),
+     * while an on-demand relation access issues a plain `=` constraint
+     * (`addWhereConstraints`) — so we assert on that instead of relying on the
+     * (non-arming) lazy-loading guard.
+     */
+    $tagsQueries = collect();
 
-    Model::preventLazyLoading(false);
+    DB::listen(function (QueryExecuted $query) use ($tagsQueries): void {
+        if (str_contains($query->sql, 'from "blog_tags"')) {
+            $tagsQueries->push($query->sql);
+        }
+    });
+
+    Model::preventLazyLoading();
+
+    try {
+        $this->get(route('blog.show', 'no-lazy'))->assertOk();
+
+        $this->get(URL::temporarySignedRoute('blog.preview', now()->addHour(), ['post' => $post]))
+            ->assertOk();
+    } finally {
+        Model::preventLazyLoading(false);
+    }
+
+    expect($tagsQueries)->toHaveCount(2, 'expected one batched tags query for show() and one for preview()');
+
+    foreach ($tagsQueries as $sql) {
+        expect($sql)->toContain('in (');
+    }
 });

--- a/tests/Feature/HostViewsTest.php
+++ b/tests/Feature/HostViewsTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Relaticle\Ink\Ink;
 use Relaticle\Ink\InkServiceProvider;
+use Relaticle\Ink\Models\Category;
 use Relaticle\Ink\Models\Post;
 use Relaticle\Ink\Models\Tag;
 
@@ -51,11 +52,15 @@ test('it renders the host view for a post when configured', function () {
 
 test('the preview view receives related posts and a null edit url by default', function () {
     config()->set('ink.views.preview', 'tests::host-preview');
-    $post = Post::factory()->create(['title' => 'Draft one']);
+
+    $category = Category::factory()->create();
+    $post = Post::factory()->create(['title' => 'Draft one', 'category_id' => $category->id]);
+    Post::factory()->published()->create(['category_id' => $category->id]);
 
     $this->get(URL::temporarySignedRoute('blog.preview', now()->addHour(), ['post' => $post]))
         ->assertOk()
         ->assertSee('HOST PREVIEW: Draft one')
+        ->assertSee('related=1')
         ->assertSee('edit=none');
 });
 

--- a/tests/Feature/HostViewsTest.php
+++ b/tests/Feature/HostViewsTest.php
@@ -2,9 +2,13 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
+use Relaticle\Ink\Ink;
 use Relaticle\Ink\InkServiceProvider;
 use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Models\Tag;
 
 beforeEach(function () {
     config()->set('ink.features.public_routes', true);
@@ -13,6 +17,8 @@ beforeEach(function () {
     $this->app->register(InkServiceProvider::class, force: true);
     $this->app->getProvider(InkServiceProvider::class)->packageBooted();
     Route::getRoutes()->refreshNameLookups();
+
+    Ink::flushState();
 });
 
 test('it renders ink pages when no host view is configured', function () {
@@ -39,4 +45,37 @@ test('it renders the host view for a post when configured', function () {
     $this->get(route('blog.show', 'hello-host'))
         ->assertOk()
         ->assertSee('HOST SHOW: Hello host');
+});
+
+test('the preview view receives related posts and a null edit url by default', function () {
+    config()->set('ink.views.preview', 'tests::host-preview');
+    $post = Post::factory()->create(['title' => 'Draft one']);
+
+    $this->get(URL::temporarySignedRoute('blog.preview', now()->addHour(), ['post' => $post]))
+        ->assertOk()
+        ->assertSee('HOST PREVIEW: Draft one')
+        ->assertSee('edit=none');
+});
+
+test('a host hook supplies the preview edit url', function () {
+    config()->set('ink.views.preview', 'tests::host-preview');
+    Ink::resolvePreviewEditUrlUsing(fn (Post $post): string => "https://admin.test/posts/{$post->id}/edit");
+
+    $post = Post::factory()->create(['title' => 'Draft two']);
+
+    $this->get(URL::temporarySignedRoute('blog.preview', now()->addHour(), ['post' => $post]))
+        ->assertOk()
+        ->assertSee("edit=https://admin.test/posts/{$post->id}/edit");
+});
+
+test('show and preview do not lazy-load tags', function () {
+    config()->set('ink.views.show', 'tests::host-show');
+    Model::preventLazyLoading();
+
+    $post = Post::factory()->published()->create(['slug' => 'no-lazy']);
+    $post->tags()->attach(Tag::factory()->create());
+
+    $this->get(route('blog.show', 'no-lazy'))->assertOk();
+
+    Model::preventLazyLoading(false);
 });

--- a/tests/Feature/HostViewsTest.php
+++ b/tests/Feature/HostViewsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Relaticle\Ink\InkServiceProvider;
+use Relaticle\Ink\Models\Post;
+
+beforeEach(function () {
+    config()->set('ink.features.public_routes', true);
+    config()->set('ink.layout', 'tests::layouts.empty');
+
+    $this->app->register(InkServiceProvider::class, force: true);
+    $this->app->getProvider(InkServiceProvider::class)->packageBooted();
+    Route::getRoutes()->refreshNameLookups();
+});
+
+test('it renders ink pages when no host view is configured', function () {
+    Post::factory()->published()->create(['title' => 'Default rendering']);
+
+    $this->get(route('blog.index'))
+        ->assertOk()
+        ->assertDontSee('HOST INDEX');
+});
+
+test('it renders the host view for the index when configured', function () {
+    config()->set('ink.views.index', 'tests::host-index');
+    Post::factory(2)->published()->create();
+
+    $this->get(route('blog.index'))
+        ->assertOk()
+        ->assertSee('HOST INDEX: 2 posts');
+});
+
+test('it renders the host view for a post when configured', function () {
+    config()->set('ink.views.show', 'tests::host-show');
+    $post = Post::factory()->published()->create(['title' => 'Hello host', 'slug' => 'hello-host']);
+
+    $this->get(route('blog.show', 'hello-host'))
+        ->assertOk()
+        ->assertSee('HOST SHOW: Hello host');
+});

--- a/tests/Feature/PublicRoutesTest.php
+++ b/tests/Feature/PublicRoutesTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Relaticle\Ink\InkServiceProvider;
@@ -97,6 +98,14 @@ test('preview route 403s without signature', function () {
 test('feed route returns RSS XML when feed feature enabled', function () {
     config()->set('ink.features.feed', true);
 
+    // Clear the routes booted by beforeEach() before re-registering: otherwise the
+    // catch-all `/{slug}` from that first (feed-disabled) boot stays first in line and
+    // intercepts `/feed` before the newly-added, correctly-gated feed route is reached.
+    app('router')->setRoutes(new RouteCollection);
+    $this->app->register(InkServiceProvider::class, force: true);
+    $this->app->getProvider(InkServiceProvider::class)->packageBooted();
+    Route::getRoutes()->refreshNameLookups();
+
     Post::factory()->published()->create(['title' => 'Hello feed']);
 
     $response = $this->get(route('blog.feed'));
@@ -107,8 +116,8 @@ test('feed route returns RSS XML when feed feature enabled', function () {
     expect($response->getContent())->toContain('Hello feed');
 });
 
-test('feed route 404s when feed feature disabled', function () {
+test('feed route does not exist when feed feature disabled', function () {
     config()->set('ink.features.feed', false);
 
-    $this->get(route('blog.feed'))->assertNotFound();
+    expect(Route::has('blog.feed'))->toBeFalse();
 });

--- a/tests/Feature/PublicRoutesTest.php
+++ b/tests/Feature/PublicRoutesTest.php
@@ -120,4 +120,6 @@ test('feed route does not exist when feed feature disabled', function () {
     config()->set('ink.features.feed', false);
 
     expect(Route::has('blog.feed'))->toBeFalse();
+
+    $this->get('/blog/feed')->assertNotFound();
 });

--- a/tests/Feature/PublicRoutesTest.php
+++ b/tests/Feature/PublicRoutesTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
+use Relaticle\Ink\Ink;
 use Relaticle\Ink\InkServiceProvider;
 use Relaticle\Ink\Models\Category;
 use Relaticle\Ink\Models\Post;
@@ -16,6 +17,8 @@ beforeEach(function () {
     // Re-boot the package so routes register with the just-set config flag.
     $this->app->register(InkServiceProvider::class, force: true);
     $this->app->getProvider(InkServiceProvider::class)->packageBooted();
+
+    Ink::flushState();
 });
 
 test('public index route returns published posts when feature enabled', function () {
@@ -93,6 +96,24 @@ test('preview route 403s without signature', function () {
     $post = Post::factory()->draft()->create();
 
     $this->get(route('blog.preview', $post))->assertForbidden();
+});
+
+test('the shipped preview page renders the edit link from the host hook', function () {
+    Ink::resolvePreviewEditUrlUsing(fn (Post $post): string => "https://admin.test/posts/{$post->id}/edit");
+
+    $post = Post::factory()->draft()->create(['title' => 'Draft preview']);
+
+    $this->get(URL::temporarySignedRoute('blog.preview', now()->addHour(), ['post' => $post]))
+        ->assertOk()
+        ->assertSee("https://admin.test/posts/{$post->id}/edit", escape: false);
+});
+
+test('the shipped preview page renders no edit link when the host hook is unregistered', function () {
+    $post = Post::factory()->draft()->create(['title' => 'Draft preview']);
+
+    $this->get(URL::temporarySignedRoute('blog.preview', now()->addHour(), ['post' => $post]))
+        ->assertOk()
+        ->assertDontSee('Edit Post');
 });
 
 test('feed route returns RSS XML when feed feature enabled', function () {

--- a/tests/Feature/PublicRoutesTest.php
+++ b/tests/Feature/PublicRoutesTest.php
@@ -116,6 +116,14 @@ test('the shipped preview page renders no edit link when the host hook is unregi
         ->assertDontSee('Edit Post');
 });
 
+test('the shipped preview page always renders noindex, even under a layout without @stack(head)', function () {
+    $post = Post::factory()->draft()->create(['title' => 'Draft preview']);
+
+    $this->get(URL::temporarySignedRoute('blog.preview', now()->addHour(), ['post' => $post]))
+        ->assertOk()
+        ->assertSee('noindex', escape: false);
+});
+
 test('feed route returns RSS XML when feed feature enabled', function () {
     config()->set('ink.features.feed', true);
 

--- a/tests/Feature/TableOfContentsTest.php
+++ b/tests/Feature/TableOfContentsTest.php
@@ -36,3 +36,15 @@ test('it strips the injected permalink symbol from the label', function () {
 
     expect(array_values($post->tableOfContents()))->toBe(['Plain heading']);
 });
+
+test('it accepts a non-default heading level', function () {
+    $post = Post::factory()->create(['content' => "### Subsection heading\n\nBody."]);
+
+    expect(array_values($post->tableOfContents('h3')))->toBe(['Subsection heading']);
+});
+
+test('it rejects a tag outside the h1-h6 allowlist', function () {
+    $post = Post::factory()->create(['content' => "## Heading\n\nBody."]);
+
+    $post->tableOfContents('h2|//p');
+})->throws(InvalidArgumentException::class);

--- a/tests/Feature/TableOfContentsTest.php
+++ b/tests/Feature/TableOfContentsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\Ink\Models\Post;
+
+test('it keeps the full label when a heading contains inline markup', function () {
+    $post = Post::factory()->create([
+        'content' => "## Why **we** built it\n\nBody.\n\n## Using `artisan` commands\n\nBody.",
+    ]);
+
+    expect(array_values($post->tableOfContents()))
+        ->toBe(['Why we built it', 'Using artisan commands']);
+});
+
+test('it decodes entities exactly once', function () {
+    $post = Post::factory()->create(['content' => "## Ampersands & more\n\nBody."]);
+
+    expect(array_values($post->tableOfContents()))->toBe(['Ampersands & more']);
+});
+
+test('it keys entries by the permalink anchor id', function () {
+    $post = Post::factory()->create(['content' => "## Why we built it\n\nBody."]);
+
+    expect(array_keys($post->tableOfContents()))->toBe(['why-we-built-it']);
+});
+
+test('it returns an empty array for a post with no headings', function () {
+    $post = Post::factory()->create(['content' => 'Just a paragraph.']);
+
+    expect($post->tableOfContents())->toBe([]);
+});
+
+test('it strips the injected permalink symbol from the label', function () {
+    $post = Post::factory()->create(['content' => "## Plain heading\n\nBody."]);
+
+    expect(array_values($post->tableOfContents()))->toBe(['Plain heading']);
+});

--- a/tests/Fixtures/views/host-index.blade.php
+++ b/tests/Fixtures/views/host-index.blade.php
@@ -1,0 +1,1 @@
+HOST INDEX: {{ $posts->total() }} posts

--- a/tests/Fixtures/views/host-preview.blade.php
+++ b/tests/Fixtures/views/host-preview.blade.php
@@ -1,1 +1,1 @@
-HOST PREVIEW: {{ $post->title }} / related={{ $relatedPosts->count() }} / edit={{ $editUrl ?? 'none' }}
+HOST PREVIEW: {{ $post->title }} / related={{ $relatedPosts->count() }} / edit={{ $editUrl ?? 'none' }} / tags={{ $post->tags->count() }}

--- a/tests/Fixtures/views/host-preview.blade.php
+++ b/tests/Fixtures/views/host-preview.blade.php
@@ -1,0 +1,1 @@
+HOST PREVIEW: {{ $post->title }} / related={{ $relatedPosts->count() }} / edit={{ $editUrl ?? 'none' }}

--- a/tests/Fixtures/views/host-show.blade.php
+++ b/tests/Fixtures/views/host-show.blade.php
@@ -1,1 +1,1 @@
-HOST SHOW: {{ $post->title }} / related={{ $relatedPosts->count() }}
+HOST SHOW: {{ $post->title }} / related={{ $relatedPosts->count() }} / tags={{ $post->tags->count() }}

--- a/tests/Fixtures/views/host-show.blade.php
+++ b/tests/Fixtures/views/host-show.blade.php
@@ -1,0 +1,1 @@
+HOST SHOW: {{ $post->title }} / related={{ $relatedPosts->count() }}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Gate;
 use Laravel\Mcp\Server\McpServiceProvider;
 use Laravel\Sanctum\SanctumServiceProvider;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use RalphJSmit\Laravel\SEO\LaravelSEOServiceProvider as RalphSEOServiceProvider;
@@ -28,6 +29,7 @@ use Relaticle\Ink\Models\Post;
 use Relaticle\Ink\Tests\Fixtures\Models\TokenUser;
 use Relaticle\Ink\Tests\Fixtures\Policies\CategoryPolicy;
 use Relaticle\Ink\Tests\Fixtures\Policies\PostPolicy;
+use Spatie\LaravelMarkdown\MarkdownServiceProvider;
 use Spatie\Sluggable\SluggableServiceProvider;
 
 class TestCase extends BaseTestCase
@@ -51,6 +53,7 @@ class TestCase extends BaseTestCase
             SanctumServiceProvider::class,
             RalphSEOServiceProvider::class,
             SluggableServiceProvider::class,
+            MarkdownServiceProvider::class,
             InkServiceProvider::class,
         ];
     }
@@ -68,6 +71,22 @@ class TestCase extends BaseTestCase
         $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
 
         $app['config']->set('ink.author_model', TokenUser::class);
+
+        // Post::tableOfContents() depends on the heading permalink anchors this
+        // extension injects — mirror the host's markdown config so the anchor's
+        // id (not the heading's own, HTML-slugified id) is exercised in tests.
+        $app['config']->set('markdown.extensions', [HeadingPermalinkExtension::class]);
+        $app['config']->set('markdown.commonmark_options.heading_permalink', [
+            'html_class' => 'heading-permalink',
+            'id_prefix' => '',
+            'fragment_prefix' => '',
+            'insert' => 'before',
+            'min_heading_level' => 1,
+            'max_heading_level' => 6,
+            'title' => 'Permalink',
+            'symbol' => '#',
+            'aria_hidden' => false,
+        ]);
 
         $app['view']->addNamespace('tests', __DIR__.'/Fixtures/views');
 


### PR DESCRIPTION
Hosts that need bespoke blog markup were reimplementing ink's entire `BlogController`. The cause was the layout seam: ink's pages use `@extends(config('ink.layout'))` — Blade inheritance, which cannot pass props to a component layout like `<x-guest-layout :title="..." :description="...">`. So a host wrote its own views, and then needed its own controllers to render them. The copies silently lost ink's listing SEO (including the page-aware canonical), `?q=` search, and `withQueryString()`.

## The seams

- **`ink.views`** — a map of view names per action, `null` falling back to `ink::pages.*`. Plain strings, so `config:cache` stays safe. This is the Spatie lever (`media_model`, `path_generator`), not Fortify's callbacks, because a view name carries everything here.
- **`ink.middleware`** — applied to the whole blog route group, default `['web']`.
- **`Ink::resolvePreviewEditUrlUsing()`** — which panel and guard own the blog admin is a host decision; hardcoding it broke a real host when it moved its admin between panels.
- **`Post::tableOfContents()`** — DOM-parsed, so headings keep inline markup and entities decode once. This was host-side, where it reverse-engineered the output of `Post::toHtml()` — ink's own method — and shipped two bugs doing it.
- **Preview** now receives `relatedPosts` and `editUrl`; `show` and `preview` eager-load `tags`.

Publishing views is explicitly documented as *not* the recommended route: Laravel does resolve `resources/views/vendor/ink/**` first, but a published file is a frozen copy that stops receiving upstream fixes.

## Route fixes

`blog.preview` is constrained to `[0-9]{1,18}`. `whereNumber` alone was not enough — `[0-9]+` is unbounded, so an over-long digit string still reached route-model binding and threw `SQLSTATE[22003] Numeric value out of range` on PostgreSQL: a 500 on a public, unauthenticated route, since `SubstituteBindings` runs before `signed`.

`blog.feed` registers only when `ink.features.feed` is on, replacing a runtime abort. `blog.tag` deliberately stays registered with its abort intact — an existing test resolves `route('blog.tag', ...)` while the feature is off.

## Tests

63 → 102. The review loop caught three tests that could not fail and one regression the fix wave itself introduced:

- `Model::preventLazyLoading()` is a no-op for single-row fetches, so the eager-load test was inert — replaced with a `DB::listen` query-shape assertion.
- The `whereNumber` test passed under SQLite regardless, because loose type affinity 404s instead of throwing — replaced with a direct assertion on the compiled route pattern.
- `Post::tableOfContents()` interpolated `$tag` into XPath unescaped; `'h2|//p'` returned paragraphs and `'h2['` raised a warning Laravel converts to a 500. Now allowlisted to `h[1-6]`.
- Switching the shipped preview page to the banner component moved its `noindex` meta into `@push('head')`, which silently vanishes under a layout without `@stack('head')` — leaving draft previews with a crawl-permissive robots tag. Now rendered unconditionally, with a test.

## Compatibility

Additive for hosts on ink's own views. `views` and `middleware` are new top-level config keys, so they survive `mergeConfigFrom`'s shallow merge for hosts that have published `config/ink.php` — documented, along with the trap that keys added *inside* `features` do not.