### PR TITLE
feat(mcp): tags support — tags param on create/update-post, list-tags-tool

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,25 @@
 # Upgrading
 
+## To 2.5 from 2.4
+
+No breaking changes — 2.5 is additive.
+
+### Tags over MCP
+
+`create-post-tool` and `update-post-tool` accept a `tags` array of tag **names**.
+Existing tags are matched case-insensitively; unknown names are created; on
+update the set is replaced in full, an empty array clears it, and omitting the
+key leaves tags untouched. `get-post-tool` and `list-posts-tool` now include a
+`tags` field. A new `list-tags-tool` returns the vocabulary with post counts so
+agents reuse tags instead of inventing near-duplicates.
+
+Everything is gated on `ink.features.tags`: with the feature disabled the
+`tags` parameter is rejected with a clear validation error and `list-tags-tool`
+is not registered. Hosts that declare their own server class with a manual
+`$tools` list must add `ListTagsTool::class` themselves. No new policy is
+required — tag reads/writes authorize through the existing `Post` policy
+(`viewAny`/`create`/`update`), since tags are post metadata.
+
 ## To 2.4 from 2.3
 
 ### `blog.preview` is now registered when `features.mcp` is enabled, not only `features.public_routes`

--- a/src/Mcp/BlogServer.php
+++ b/src/Mcp/BlogServer.php
@@ -18,6 +18,7 @@ use Relaticle\Ink\Mcp\Tools\GetCategoryTool;
 use Relaticle\Ink\Mcp\Tools\GetPostTool;
 use Relaticle\Ink\Mcp\Tools\ListCategoriesTool;
 use Relaticle\Ink\Mcp\Tools\ListPostsTool;
+use Relaticle\Ink\Mcp\Tools\ListTagsTool;
 use Relaticle\Ink\Mcp\Tools\RestoreCategoryTool;
 use Relaticle\Ink\Mcp\Tools\RestorePostTool;
 use Relaticle\Ink\Mcp\Tools\UpdateCategoryTool;
@@ -26,7 +27,7 @@ use Relaticle\Ink\Mcp\Tools\UploadImageTool;
 
 #[Name('Blog')]
 #[Version('2.0.0')]
-#[Instructions('Manage blog posts and categories. Full CRUD with soft delete (no hard delete). Posts carry title, markdown content, excerpt, category, status (draft/published) and published_at — a future published_at with status published schedules the post; it appears on public/feed/sitemap routes automatically once the clock passes, no further action needed. Use upload-image to get a storage path for a featured_image or an in-content markdown image.')]
+#[Instructions('Manage blog posts and categories. Full CRUD with soft delete (no hard delete). Posts carry title, markdown content, excerpt, category, status (draft/published) and published_at — a future published_at with status published schedules the post; it appears on public/feed/sitemap routes automatically once the clock passes, no further action needed. Posts carry tags (names, synced via the tags param) when the tags feature is enabled. Use upload-image to get a storage path for a featured_image or an in-content markdown image.')]
 class BlogServer extends Server
 {
     /** @var array<int, class-string<Tool>> */
@@ -39,6 +40,7 @@ class BlogServer extends Server
         RestorePostTool::class,
         GeneratePreviewUrlTool::class,
         UploadImageTool::class,
+        ListTagsTool::class,
         ListCategoriesTool::class,
         GetCategoryTool::class,
         CreateCategoryTool::class,

--- a/src/Mcp/BlogTool.php
+++ b/src/Mcp/BlogTool.php
@@ -18,6 +18,8 @@ use Laravel\Mcp\ResponseFactory;
 use Laravel\Mcp\Server\Tool;
 use League\Flysystem\FilesystemException;
 use Relaticle\Ink\Ink;
+use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Models\Tag;
 
 /**
  * Base class for the blog tools.
@@ -75,6 +77,53 @@ abstract class BlogTool extends Tool
         if (method_exists($caller, 'tokenCan') && ! $caller->tokenCan($this->tokenAbility())) {
             throw new AuthorizationException("Token missing required ability: {$this->tokenAbility()}");
         }
+    }
+
+    /**
+     * Validation rules for the shared `tags` parameter. Rejects the parameter
+     * outright when the host has the tags feature disabled, so an agent gets a
+     * clear error instead of a silent no-op.
+     *
+     * @return array<string, list<mixed>>
+     */
+    protected function tagsRules(): array
+    {
+        return [
+            'tags' => ['nullable', 'array', 'max:20', function (string $attribute, mixed $value, Closure $fail): void {
+                if (! config('ink.features.tags')) {
+                    $fail('Tags are disabled on this blog (ink.features.tags is false).');
+                }
+            }],
+            'tags.*' => ['string', 'max:50'],
+        ];
+    }
+
+    /**
+     * Sync a post's tags from a list of names. Existing tags are matched
+     * case-insensitively so agents cannot fragment the vocabulary ("MCP" vs
+     * "mcp"); unknown names are created. An empty list detaches everything.
+     *
+     * @param  list<string>  $names
+     */
+    protected function syncTagsFromNames(Post $post, array $names): void
+    {
+        $ids = [];
+
+        foreach ($names as $name) {
+            $name = trim($name);
+
+            if ($name === '') {
+                continue;
+            }
+
+            $tag = Tag::query()
+                ->whereRaw('lower(name) = ?', [mb_strtolower($name)])
+                ->first() ?? Tag::create(['name' => $name]);
+
+            $ids[$tag->getKey()] = true;
+        }
+
+        $post->tags()->sync(array_keys($ids));
     }
 
     protected function caller(Request $request): ?Authenticatable

--- a/src/Mcp/Tools/CreatePostTool.php
+++ b/src/Mcp/Tools/CreatePostTool.php
@@ -48,6 +48,7 @@ class CreatePostTool extends BlogTool
             'published_at' => ['nullable', 'date'],
             'seo_title' => ['nullable', 'string', 'max:60'],
             'seo_description' => ['nullable', 'string', 'max:160'],
+            ...$this->tagsRules(),
         ], [
             'title.required' => 'A title is required to create a post.',
             'content.required' => 'Content is required to create a post.',
@@ -79,7 +80,11 @@ class CreatePostTool extends BlogTool
             ]));
         }
 
-        $post->load('category');
+        if (array_key_exists('tags', $validated) && is_array($validated['tags'])) {
+            $this->syncTagsFromNames($post, array_values($validated['tags']));
+        }
+
+        $post->load(['category', 'tags']);
 
         return Response::structured([
             'id' => $post->id,
@@ -88,6 +93,7 @@ class CreatePostTool extends BlogTool
             'status' => $post->status->value,
             'category' => $post->category?->name,
             'featured_image' => $post->featured_image,
+            'tags' => $post->tags->pluck('name')->all(),
             'seo_title' => $post->seo->title,
             'seo_description' => $post->seo->description,
             'published_at' => $post->published_at?->toIso8601String(),
@@ -108,6 +114,7 @@ class CreatePostTool extends BlogTool
             'published_at' => $schema->string()->description('ISO 8601 publish date. Required when status is published.'),
             'seo_title' => $schema->string()->description('Custom SEO meta title (max 60 chars). Falls back to post title if not set.'),
             'seo_description' => $schema->string()->description('Custom SEO meta description (max 160 chars). Falls back to excerpt if not set.'),
+            'tags' => $schema->array()->items($schema->string())->description('Tag names. Existing tags are matched case-insensitively; unknown names are created. Requires the tags feature.'),
         ];
     }
 }

--- a/src/Mcp/Tools/GetPostTool.php
+++ b/src/Mcp/Tools/GetPostTool.php
@@ -39,9 +39,9 @@ class GetPostTool extends BlogTool
         $post = null;
 
         if ($id = $request->get('id')) {
-            $post = Post::with(['category', 'seo'])->find($id);
+            $post = Post::with(['category', 'seo', 'tags'])->find($id);
         } elseif ($slug = $request->get('slug')) {
-            $post = Post::with(['category', 'seo'])->where('slug', $slug)->first();
+            $post = Post::with(['category', 'seo', 'tags'])->where('slug', $slug)->first();
         }
 
         return $post ?? Response::error('Post not found. Provide a valid id or slug.');
@@ -62,6 +62,7 @@ class GetPostTool extends BlogTool
             'status' => $post->status->value,
             'category_id' => $post->category_id,
             'category' => $post->category?->name,
+            'tags' => $post->tags->pluck('name')->all(),
             'author_id' => $post->author_id,
             'seo_title' => $post->seo->title,
             'seo_description' => $post->seo->description,

--- a/src/Mcp/Tools/ListPostsTool.php
+++ b/src/Mcp/Tools/ListPostsTool.php
@@ -38,7 +38,7 @@ class ListPostsTool extends BlogTool
     protected function run(Request $request, ?Model $record): Response|ResponseFactory
     {
 
-        $query = Post::query()->with('category');
+        $query = Post::query()->with(['category', 'tags']);
 
         if ($status = $request->get('status')) {
             $query->where('status', $status);
@@ -69,6 +69,7 @@ class ListPostsTool extends BlogTool
                 'excerpt' => $post->excerpt,
                 'status' => $post->status->value,
                 'category' => $post->category?->name,
+                'tags' => $post->tags->pluck('name')->all(),
                 'author_id' => $post->author_id,
                 'published_at' => $post->published_at?->toIso8601String(),
                 'created_at' => $post->created_at->toIso8601String(),

--- a/src/Mcp/Tools/ListTagsTool.php
+++ b/src/Mcp/Tools/ListTagsTool.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Ink\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\JsonSchema\Types\Type;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Relaticle\Ink\Mcp\BlogTool;
+use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Models\Tag;
+
+#[Description('List all blog tags with their post counts. Check this before tagging a post so existing tags are reused instead of creating near-duplicates.')]
+class ListTagsTool extends BlogTool
+{
+    /**
+     * Tags are post metadata: readable by anyone who may list posts. Gating on
+     * the Post policy keeps existing hosts working without registering a new
+     * Tag policy.
+     */
+    protected function ability(): string
+    {
+        return 'viewAny';
+    }
+
+    protected function tokenAbility(): string
+    {
+        return 'posts:read';
+    }
+
+    protected function model(): string
+    {
+        return Post::class;
+    }
+
+    public function shouldRegister(): bool
+    {
+        return (bool) config('ink.features.tags');
+    }
+
+    protected function run(Request $request, ?Model $record): Response|ResponseFactory
+    {
+        $tags = Tag::query()
+            ->withCount('posts')
+            ->orderBy('name')
+            ->get();
+
+        if ($tags->isEmpty()) {
+            return Response::text('No tags exist yet.');
+        }
+
+        return Response::structured([
+            'data' => $tags->map(fn (Tag $tag): array => [
+                'id' => $tag->getKey(),
+                'name' => $tag->name,
+                'slug' => $tag->slug,
+                'posts_count' => $tag->posts_count,
+            ])->all(),
+        ]);
+    }
+
+    /** @return array<string, Type> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/src/Mcp/Tools/UpdatePostTool.php
+++ b/src/Mcp/Tools/UpdatePostTool.php
@@ -66,6 +66,7 @@ class UpdatePostTool extends BlogTool
             'published_at' => ['nullable', 'date'],
             'seo_title' => ['nullable', 'string', 'max:60'],
             'seo_description' => ['nullable', 'string', 'max:160'],
+            ...$this->tagsRules(),
         ], [
             'id.required' => 'You must provide the post ID to update.',
         ]);
@@ -109,7 +110,11 @@ class UpdatePostTool extends BlogTool
             $post->seo->update($seoData);
         }
 
-        $post->load('category');
+        if ($request->has('tags')) {
+            $this->syncTagsFromNames($post, array_values($validated['tags'] ?? []));
+        }
+
+        $post->load(['category', 'tags']);
 
         return Response::structured([
             'id' => $post->id,
@@ -118,6 +123,7 @@ class UpdatePostTool extends BlogTool
             'status' => $post->status->value,
             'category' => $post->category?->name,
             'featured_image' => $post->featured_image,
+            'tags' => $post->tags->pluck('name')->all(),
             'seo_title' => $post->seo->title,
             'seo_description' => $post->seo->description,
             'published_at' => $post->published_at?->toIso8601String(),
@@ -139,6 +145,7 @@ class UpdatePostTool extends BlogTool
             'published_at' => $schema->string()->description('New publish date (ISO 8601).'),
             'seo_title' => $schema->string()->description('Custom SEO meta title (max 60 chars).'),
             'seo_description' => $schema->string()->description('Custom SEO meta description (max 160 chars).'),
+            'tags' => $schema->array()->items($schema->string())->description('Tag names to sync. Replaces the full set; an empty array clears all tags; omit to leave tags untouched.'),
         ];
     }
 }

--- a/tests/Feature/Mcp/TagsTest.php
+++ b/tests/Feature/Mcp/TagsTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\Ink\Mcp\BlogServer;
+use Relaticle\Ink\Mcp\Tools\CreatePostTool;
+use Relaticle\Ink\Mcp\Tools\GetPostTool;
+use Relaticle\Ink\Mcp\Tools\ListPostsTool;
+use Relaticle\Ink\Mcp\Tools\ListTagsTool;
+use Relaticle\Ink\Mcp\Tools\UpdatePostTool;
+use Relaticle\Ink\Models\Category;
+use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Models\Tag;
+
+beforeEach(function () {
+    config()->set('ink.features.tags', true);
+});
+
+function postArgs(Category $category, array $extra = []): array
+{
+    return [
+        'title' => 'Tagged post',
+        'content' => '## Hello',
+        'excerpt' => 'An excerpt.',
+        'category_id' => $category->id,
+        ...$extra,
+    ];
+}
+
+test('create-post-tool attaches tags by name and returns them', function () {
+    $category = Category::factory()->create();
+
+    BlogServer::actingAs(tokenUser())
+        ->tool(CreatePostTool::class, postArgs($category, ['tags' => ['MCP', 'Laravel']]))
+        ->assertOk();
+
+    $post = Post::where('title', 'Tagged post')->firstOrFail();
+
+    expect($post->tags->pluck('name')->sort()->values()->all())->toBe(['Laravel', 'MCP'])
+        ->and(Tag::count())->toBe(2);
+});
+
+test('create-post-tool reuses existing tags case-insensitively', function () {
+    Tag::create(['name' => 'MCP']);
+    $category = Category::factory()->create();
+
+    BlogServer::actingAs(tokenUser())
+        ->tool(CreatePostTool::class, postArgs($category, ['tags' => ['mcp', ' Laravel ']]))
+        ->assertOk();
+
+    expect(Tag::count())->toBe(2)
+        ->and(Tag::pluck('name')->sort()->values()->all())->toBe(['Laravel', 'MCP']);
+});
+
+test('update-post-tool replaces the tag set and an empty array clears it', function () {
+    $post = Post::factory()->for(Category::factory())->create();
+    $post->tags()->sync([Tag::create(['name' => 'Old'])->id]);
+
+    $user = tokenUser();
+
+    BlogServer::actingAs($user)
+        ->tool(UpdatePostTool::class, ['id' => $post->id, 'tags' => ['Fresh']])
+        ->assertOk();
+
+    expect($post->refresh()->tags->pluck('name')->all())->toBe(['Fresh']);
+
+    BlogServer::actingAs($user)
+        ->tool(UpdatePostTool::class, ['id' => $post->id, 'tags' => []])
+        ->assertOk();
+
+    expect($post->refresh()->tags)->toHaveCount(0);
+});
+
+test('update-post-tool leaves tags untouched when the parameter is omitted', function () {
+    $post = Post::factory()->for(Category::factory())->create();
+    $post->tags()->sync([Tag::create(['name' => 'Keep'])->id]);
+
+    BlogServer::actingAs(tokenUser())
+        ->tool(UpdatePostTool::class, ['id' => $post->id, 'title' => 'Renamed'])
+        ->assertOk();
+
+    expect($post->refresh()->tags->pluck('name')->all())->toBe(['Keep']);
+});
+
+test('get-post-tool and list-posts-tool include tag names', function () {
+    $post = Post::factory()->for(Category::factory())->create();
+    $post->tags()->sync([Tag::create(['name' => 'Visible'])->id]);
+
+    $user = tokenUser();
+
+    BlogServer::actingAs($user)
+        ->tool(GetPostTool::class, ['id' => $post->id])
+        ->assertOk()
+        ->assertSee('Visible');
+
+    BlogServer::actingAs($user)
+        ->tool(ListPostsTool::class)
+        ->assertOk()
+        ->assertSee('Visible');
+});
+
+test('list-tags-tool returns the vocabulary with post counts', function () {
+    $post = Post::factory()->for(Category::factory())->create();
+    $tag = Tag::create(['name' => 'Guides']);
+    Tag::create(['name' => 'Unused']);
+    $post->tags()->sync([$tag->id]);
+
+    BlogServer::actingAs(tokenUser())
+        ->tool(ListTagsTool::class)
+        ->assertOk()
+        ->assertSee('Guides')
+        ->assertSee('Unused');
+});
+
+test('the tags parameter is rejected when the tags feature is disabled', function () {
+    config()->set('ink.features.tags', false);
+    $category = Category::factory()->create();
+
+    BlogServer::actingAs(tokenUser())
+        ->tool(CreatePostTool::class, postArgs($category, ['tags' => ['MCP']]))
+        ->assertHasErrors();
+
+    expect(Post::where('title', 'Tagged post')->exists())->toBeFalse();
+});
+
+test('list-tags-tool is not registered when the tags feature is disabled', function () {
+    config()->set('ink.features.tags', false);
+
+    expect((new ListTagsTool)->shouldRegister())->toBeFalse();
+
+    config()->set('ink.features.tags', true);
+
+    expect((new ListTagsTool)->shouldRegister())->toBeTrue();
+});
+
+test('a non-array tags value is rejected with a clean validation error', function () {
+    $category = Category::factory()->create();
+
+    BlogServer::actingAs(tokenUser())
+        ->tool(CreatePostTool::class, postArgs($category, ['tags' => 'not-a-list']))
+        ->assertHasErrors();
+});


### PR DESCRIPTION
## What

- `tags` array param (tag **names**) on `create-post-tool` and `update-post-tool`: existing tags matched case-insensitively, unknown names created; on update the set is replaced in full, `[]` clears, omitted key leaves tags untouched
- `get-post-tool` / `list-posts-tool` responses now include `tags`
- New `list-tags-tool` (vocabulary + post counts) so agents reuse tags instead of inventing near-duplicates
- Everything gated on `ink.features.tags`: param rejected with a clean validation error when off; `list-tags-tool` unregistered via `shouldRegister()`
- No new policy required — authorizes through the existing `Post` policy (tags are post metadata); documented in UPGRADING.md

## Why

The tags taxonomy has existed since 1.4 but was Filament-panel-only. An agent managing the blog over MCP could neither read nor set tags — by our own standard (any field reachable in the panel must be settable from the agent surface) that's a gap, not a limitation.

## Test plan

- 9 new tests in `tests/Feature/Mcp/TagsTest.php`: create/attach, case-insensitive reuse, replace/clear/omit semantics, tags in get/list, list-tags output, feature-disabled rejection + non-registration, non-array rejection
- Full suite: 184 passed