### PR TITLE
fix: free slugs held by soft-deleted posts, add slug to mcp tools

### DIFF
--- a/src/Mcp/BlogTool.php
+++ b/src/Mcp/BlogTool.php
@@ -99,6 +99,31 @@ abstract class BlogTool extends Tool
     }
 
     /**
+     * Rejects a slug already worn by another live post.
+     *
+     * Trashed posts are excluded on purpose: the models release their slug
+     * when soft-deleted, so refusing one here would block a slug the write
+     * would in fact accept.
+     */
+    protected function uniqueSlugRule(?Post $ignoring = null): Closure
+    {
+        return function (string $attribute, mixed $value, Closure $fail) use ($ignoring): void {
+            if (! is_string($value) || $value === '') {
+                return;
+            }
+
+            $taken = Post::query()
+                ->where('slug', $value)
+                ->when($ignoring?->exists, fn ($query) => $query->whereKeyNot($ignoring->getKey()))
+                ->exists();
+
+            if ($taken) {
+                $fail("The slug \"{$value}\" is already used by another post.");
+            }
+        };
+    }
+
+    /**
      * Sync a post's tags from a list of names. Existing tags are matched
      * case-insensitively so agents cannot fragment the vocabulary ("MCP" vs
      * "mcp"); unknown names are created. An empty list detaches everything.

--- a/src/Mcp/Tools/CreatePostTool.php
+++ b/src/Mcp/Tools/CreatePostTool.php
@@ -40,6 +40,7 @@ class CreatePostTool extends BlogTool
 
         $validated = $request->validate([
             'title' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', $this->uniqueSlugRule()],
             'content' => ['required', 'string'],
             'excerpt' => ['required', 'string', 'max:500'],
             'featured_image' => ['nullable', 'string', $this->featuredImagePathRule()],
@@ -64,6 +65,7 @@ class CreatePostTool extends BlogTool
 
         $post = Post::create([
             'title' => $validated['title'],
+            'slug' => $validated['slug'] ?? null,
             'content' => $validated['content'],
             'excerpt' => $validated['excerpt'],
             'featured_image' => $validated['featured_image'] ?? null,
@@ -106,6 +108,7 @@ class CreatePostTool extends BlogTool
     {
         return [
             'title' => $schema->string()->description('The post title.')->required(),
+            'slug' => $schema->string()->description('URL slug. Generated from the title when omitted. Must be unique among live posts; a slug held only by a deleted post is reusable.'),
             'content' => $schema->string()->description('The post content in Markdown. Converted to HTML on save.')->required(),
             'excerpt' => $schema->string()->description('Short excerpt/summary of the post.')->required(),
             'featured_image' => $schema->string()->description('Featured image path, as returned by upload-image (e.g. "ink/xxx.webp").'),

--- a/src/Mcp/Tools/UpdatePostTool.php
+++ b/src/Mcp/Tools/UpdatePostTool.php
@@ -58,6 +58,7 @@ class UpdatePostTool extends BlogTool
         $validated = $request->validate([
             'id' => ['required', 'integer'],
             'title' => ['nullable', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255', $this->uniqueSlugRule($post)],
             'content' => ['nullable', 'string'],
             'excerpt' => ['nullable', 'string', 'max:500'],
             'featured_image' => ['nullable', 'string', $this->featuredImagePathRule()],
@@ -77,6 +78,7 @@ class UpdatePostTool extends BlogTool
 
         $data = array_filter([
             'title' => $validated['title'] ?? null,
+            'slug' => $validated['slug'] ?? null,
             'content' => $content,
             'excerpt' => $validated['excerpt'] ?? null,
             'category_id' => $validated['category_id'] ?? null,
@@ -137,6 +139,7 @@ class UpdatePostTool extends BlogTool
         return [
             'id' => $schema->integer()->description('The post ID to update.')->required(),
             'title' => $schema->string()->description('New title.'),
+            'slug' => $schema->string()->description('New URL slug. Changing this breaks existing links to the post. Must be unique among live posts; a slug held only by a deleted post is reusable.'),
             'content' => $schema->string()->description('New content in Markdown. Converted to HTML on save.'),
             'excerpt' => $schema->string()->description('New excerpt.'),
             'featured_image' => $schema->string()->description('New featured image path, as returned by upload-image (e.g. "ink/xxx.webp"). Pass null to clear it.'),

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Relaticle\Ink\Database\Factories\CategoryFactory;
+use Relaticle\Ink\Models\Concerns\ReclaimsTrashedSlugs;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
@@ -16,6 +17,9 @@ class Category extends Model
 {
     use HasFactory;
     use HasSlug;
+    use ReclaimsTrashedSlugs {
+        ReclaimsTrashedSlugs::generateSlugAction insteadof HasSlug;
+    }
     use SoftDeletes;
 
     protected $table = 'blog_categories';

--- a/src/Models/Concerns/ReclaimsTrashedSlugs.php
+++ b/src/Models/Concerns/ReclaimsTrashedSlugs.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Ink\Models\Concerns;
+
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Relaticle\Ink\Support\ReclaimsTrashedSlugsAction;
+use Spatie\Sluggable\Actions\GenerateSlugAction;
+
+/**
+ * Makes a soft-deleted record's slug available to live records again.
+ *
+ * Pair with HasSlug and SoftDeletes. See ReclaimsTrashedSlugsAction for why a
+ * trashed slug has to be actively vacated rather than merely ignored.
+ */
+trait ReclaimsTrashedSlugs
+{
+    public static function bootReclaimsTrashedSlugs(): void
+    {
+        // A slug set by hand never reaches the generator, so the trashed
+        // occupant has to be cleared out here or the unique index rejects
+        // the write.
+        static::saving(function (self $model): void {
+            $slugField = $model->getSlugOptions()->slugField;
+
+            if (! $model->isDirty($slugField)) {
+                return;
+            }
+
+            $slug = (string) $model->getAttribute($slugField);
+
+            if ($slug === '') {
+                return;
+            }
+
+            $heldByLiveRecord = static::query()
+                ->withoutGlobalScopes()
+                ->withGlobalScope(SoftDeletingScope::class, new SoftDeletingScope)
+                ->where($slugField, $slug)
+                ->when($model->exists, fn ($query) => $query->whereKeyNot($model->getKey()))
+                ->exists();
+
+            if ($heldByLiveRecord) {
+                return;
+            }
+
+            $model->vacateTrashedSlug($slug);
+        });
+
+        static::restoring(function (self $model): void {
+            $options = $model->getSlugOptions();
+            $slugField = $options->slugField;
+            $slug = (string) $model->getAttribute($slugField);
+
+            if ($slug === '') {
+                return;
+            }
+
+            $taken = static::query()
+                ->withoutGlobalScopes()
+                ->where($slugField, $slug)
+                ->whereKeyNot($model->getKey())
+                ->exists();
+
+            if (! $taken) {
+                return;
+            }
+
+            $model->setAttribute(
+                $slugField,
+                (new GenerateSlugAction)->makeUnique($slug, $model, $options),
+            );
+        });
+    }
+
+    protected function generateSlugAction(): GenerateSlugAction
+    {
+        return new ReclaimsTrashedSlugsAction;
+    }
+
+    /**
+     * Re-slug the trashed records sitting on this slug so a live record can
+     * take it. They are moved aside rather than removed, since a restore has
+     * to stay possible and the unique index tolerates no duplicates.
+     */
+    public function vacateTrashedSlug(string $slug): void
+    {
+        $options = $this->getSlugOptions();
+        $action = new GenerateSlugAction;
+        $suffixing = (clone $options)->useSuffixOnFirstOccurrence();
+
+        $occupants = static::query()
+            ->withoutGlobalScopes()
+            ->where($options->slugField, $slug)
+            ->when($this->exists, fn ($query) => $query->whereKeyNot($this->getKey()))
+            ->get();
+
+        foreach ($occupants as $occupant) {
+            $occupant->setAttribute(
+                $options->slugField,
+                $action->makeUnique($slug, $occupant, $suffixing),
+            );
+
+            $occupant->saveQuietly();
+        }
+    }
+}

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -28,6 +28,7 @@ use RalphJSmit\Laravel\SEO\Support\HasSEO;
 use RalphJSmit\Laravel\SEO\Support\SEOData;
 use Relaticle\Ink\Database\Factories\PostFactory;
 use Relaticle\Ink\Enums\PostStatus;
+use Relaticle\Ink\Models\Concerns\ReclaimsTrashedSlugs;
 use Relaticle\Ink\Support\ImageAttributes;
 use Relaticle\Ink\Support\SchemaExtractor;
 use Spatie\LaravelMarkdown\MarkdownRenderer;
@@ -39,6 +40,9 @@ class Post extends Model
     use HasFactory;
     use HasSEO;
     use HasSlug;
+    use ReclaimsTrashedSlugs {
+        ReclaimsTrashedSlugs::generateSlugAction insteadof HasSlug;
+    }
     use SoftDeletes;
 
     protected $table = 'blog_posts';

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Relaticle\Ink\Database\Factories\TagFactory;
+use Relaticle\Ink\Models\Concerns\ReclaimsTrashedSlugs;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
@@ -16,6 +17,9 @@ class Tag extends Model
 {
     use HasFactory;
     use HasSlug;
+    use ReclaimsTrashedSlugs {
+        ReclaimsTrashedSlugs::generateSlugAction insteadof HasSlug;
+    }
     use SoftDeletes;
 
     protected $table = 'blog_tags';

--- a/src/Support/ReclaimsTrashedSlugsAction.php
+++ b/src/Support/ReclaimsTrashedSlugsAction.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Ink\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Spatie\Sluggable\Actions\GenerateSlugAction;
+use Spatie\Sluggable\SlugOptions;
+
+/**
+ * Lets a live record take a slug that only a soft-deleted record still holds.
+ *
+ * The parent action counts trashed rows as occupants, so deleting a post and
+ * writing it again forever yields `my-post-1`, `my-post-2`, and the clean slug
+ * is never reachable again. Here a trashed row is treated as vacant instead.
+ *
+ * The `slug` column is uniquely indexed, so vacating has to be real rather
+ * than a query trick: a soft-deleted record whose slug gets claimed is
+ * re-suffixed on the spot, and restoring it re-suffixes it again if the slug
+ * it left behind is now occupied.
+ */
+final class ReclaimsTrashedSlugsAction extends GenerateSlugAction
+{
+    public function makeUnique(string $slug, Model $model, SlugOptions $options): string
+    {
+        $unique = parent::makeUnique($slug, $model, $options);
+
+        if ($unique === $slug) {
+            return $unique;
+        }
+
+        if (! $this->modelUsesSoftDeletes($model)) {
+            return $unique;
+        }
+
+        if ($this->liveRecordExistsWithSlug($slug, $model, $options)) {
+            return $unique;
+        }
+
+        $model->vacateTrashedSlug($slug);
+
+        return $slug;
+    }
+
+    private function liveRecordExistsWithSlug(string $slug, Model $model, SlugOptions $options): bool
+    {
+        $query = $model->newQuery()
+            ->withoutGlobalScopes()
+            ->where($options->slugField, $slug);
+
+        if ($options->extraScopeCallback !== null) {
+            $query->where($options->extraScopeCallback);
+        }
+
+        if ($model->exists) {
+            $query->where($model->getKeyName(), '!=', $model->getKey());
+        }
+
+        $query->withGlobalScope(SoftDeletingScope::class, new SoftDeletingScope);
+
+        return $query->exists();
+    }
+}

--- a/tests/Feature/Mcp/SlugParameterTest.php
+++ b/tests/Feature/Mcp/SlugParameterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\Ink\Mcp\BlogServer;
+use Relaticle\Ink\Mcp\Tools\CreatePostTool;
+use Relaticle\Ink\Mcp\Tools\UpdatePostTool;
+use Relaticle\Ink\Models\Category;
+use Relaticle\Ink\Models\Post;
+
+test('create-post-tool accepts an explicit slug', function () {
+    BlogServer::actingAs(tokenUser())->tool(CreatePostTool::class, [
+        'title' => 'Some Long Marketing Title',
+        'slug' => 'short-slug',
+        'content' => '## Hello',
+        'excerpt' => 'An excerpt.',
+        'category_id' => Category::factory()->create()->id,
+    ])->assertOk();
+
+    expect(Post::query()->where('title', 'Some Long Marketing Title')->sole()->slug)
+        ->toBe('short-slug');
+});
+
+test('create-post-tool derives the slug from the title when none is given', function () {
+    BlogServer::actingAs(tokenUser())->tool(CreatePostTool::class, [
+        'title' => 'Derived From Title',
+        'content' => '## Hello',
+        'excerpt' => 'An excerpt.',
+        'category_id' => Category::factory()->create()->id,
+    ])->assertOk();
+
+    expect(Post::query()->where('title', 'Derived From Title')->sole()->slug)
+        ->toBe('derived-from-title');
+});
+
+test('create-post-tool rejects a slug already held by a live post', function () {
+    Post::factory()->create(['slug' => 'taken']);
+
+    BlogServer::actingAs(tokenUser())->tool(CreatePostTool::class, [
+        'title' => 'Colliding post',
+        'slug' => 'taken',
+        'content' => '## Hello',
+        'excerpt' => 'An excerpt.',
+        'category_id' => Category::factory()->create()->id,
+    ])->assertHasErrors();
+
+    expect(Post::query()->where('title', 'Colliding post')->exists())->toBeFalse();
+});
+
+test('update-post-tool renames a slug', function () {
+    $post = Post::factory()->create(['slug' => 'original-1']);
+
+    BlogServer::actingAs(tokenUser())->tool(UpdatePostTool::class, [
+        'id' => $post->id,
+        'slug' => 'original',
+    ])->assertOk();
+
+    expect($post->fresh()->slug)->toBe('original');
+});
+
+test('update-post-tool rejects a slug held by another live post', function () {
+    Post::factory()->create(['slug' => 'taken']);
+    $post = Post::factory()->create(['slug' => 'mine']);
+
+    BlogServer::actingAs(tokenUser())->tool(UpdatePostTool::class, [
+        'id' => $post->id,
+        'slug' => 'taken',
+    ])->assertHasErrors();
+
+    expect($post->fresh()->slug)->toBe('mine');
+});
+
+test('update-post-tool accepts a slug only a trashed post still holds', function () {
+    Post::factory()->create(['slug' => 'reclaimable'])->delete();
+    $post = Post::factory()->create(['slug' => 'reclaimable-1']);
+
+    BlogServer::actingAs(tokenUser())->tool(UpdatePostTool::class, [
+        'id' => $post->id,
+        'slug' => 'reclaimable',
+    ])->assertOk();
+
+    expect($post->fresh()->slug)->toBe('reclaimable');
+});
+
+test('update-post-tool lets a post keep its own slug', function () {
+    $post = Post::factory()->create(['slug' => 'unchanged']);
+
+    BlogServer::actingAs(tokenUser())->tool(UpdatePostTool::class, [
+        'id' => $post->id,
+        'slug' => 'unchanged',
+        'title' => 'New Title',
+    ])->assertOk();
+
+    expect($post->fresh()->slug)->toBe('unchanged');
+});

--- a/tests/Feature/SlugReclaimTest.php
+++ b/tests/Feature/SlugReclaimTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\Ink\Models\Category;
+use Relaticle\Ink\Models\Post;
+use Relaticle\Ink\Models\Tag;
+
+/**
+ * The factory assigns a random slug of its own, which would bypass the
+ * generator entirely. Omitting the attribute is what makes HasSlug run.
+ */
+function postTitled(string $title): Post
+{
+    return Post::factory()->create(['title' => $title, 'slug' => null]);
+}
+
+test('a new post reclaims the slug of a trashed post with the same title', function () {
+    $original = postTitled('Hello World');
+
+    expect($original->slug)->toBe('hello-world');
+
+    $original->delete();
+
+    expect(postTitled('Hello World')->slug)->toBe('hello-world');
+});
+
+test('a new post still suffixes past a live post with the same title', function () {
+    postTitled('Hello World');
+
+    expect(postTitled('Hello World')->slug)->toBe('hello-world-1');
+});
+
+test('restoring a post whose slug was reclaimed re-suffixes the restored post', function () {
+    $original = postTitled('Hello World');
+    $original->delete();
+
+    $replacement = postTitled('Hello World');
+    expect($replacement->slug)->toBe('hello-world');
+
+    $original->restore();
+
+    expect($original->fresh()->slug)->toBe('hello-world-1')
+        ->and($replacement->fresh()->slug)->toBe('hello-world');
+});
+
+test('categories reclaim slugs from trashed categories', function () {
+    $original = Category::factory()->create(['name' => 'Engineering']);
+    expect($original->slug)->toBe('engineering');
+
+    $original->delete();
+
+    expect(Category::factory()->create(['name' => 'Engineering'])->slug)->toBe('engineering');
+});
+
+test('tags reclaim slugs from trashed tags', function () {
+    $original = Tag::factory()->create(['name' => 'Laravel']);
+    expect($original->slug)->toBe('laravel');
+
+    $original->delete();
+
+    expect(Tag::factory()->create(['name' => 'Laravel'])->slug)->toBe('laravel');
+});
+
+test('restoring a category whose slug was reclaimed re-suffixes the restored category', function () {
+    $original = Category::factory()->create(['name' => 'Engineering']);
+    $original->delete();
+
+    Category::factory()->create(['name' => 'Engineering']);
+
+    $original->restore();
+
+    expect($original->fresh()->slug)->toBe('engineering-1');
+});
+
+test('a restored record keeps its slug when nothing reclaimed it', function () {
+    $post = postTitled('Hello World');
+    $post->delete();
+
+    $post->restore();
+
+    expect($post->fresh()->slug)->toBe('hello-world');
+});


### PR DESCRIPTION
## The bug

Soft-deleting a post reserved its slug permanently. `spatie/laravel-sluggable` deliberately counts trashed rows when testing uniqueness ([`GenerateSlugAction.php:294`](https://github.com/spatie/laravel-sluggable/blob/main/src/Actions/GenerateSlugAction.php) calls `withoutGlobalScope(SoftDeletingScope::class)` before the existence check), so writing a post, deleting it, and writing it again gives `my-post-1`, then `my-post-2`. The clean slug is never reachable again.

This is live on relaticle.com right now: 4 of 8 posts carry `-1`/`-2` suffixes, and all 4 clean URLs 404.

Worse, it was unfixable without direct DB access:

- `update-post` exposes no `slug` parameter
- `getSlugOptions()` sets `doNotGenerateSlugsOnUpdate()`, so retitling does not regenerate
- the trashed twin blocks the clean slug at both the validation layer (`unique(ignoreRecord: true)`) and the DB unique index

## The fix

Trashed records release their slug to live ones. Since `slug` is uniquely indexed, releasing has to be real rather than a query trick, so a trashed occupant is re-suffixed on the spot. Restoring it re-suffixes it again if the slug it left behind has since been claimed, so a restore can never collide.

Covers `Post`, `Category` and `Tag`, and both slug paths: generated (via the action) and hand-set (via a `saving` hook, which the generator never sees).

`create-post` and `update-post` now take an explicit `slug`, validated unique against live posts only, matching the new model behaviour.

## Verification

Repro first, as a failing test: 5 of 7 new model tests failed before the change, with the 2 passing ones pinning the behaviour that had to survive (live posts still suffix; untouched restores keep their slug).

A direct `$post->update(['slug' => ...])` still threw `UniqueConstraintViolationException` after the first pass, which is what surfaced the hand-set path. Same repro now returns the reclaimed slug.

```
Tests:    198 passed (479 assertions)   # was 191 before, +14 new, 1 pre-existing file untouched
Pint:     passed
```

Both are exactly what CI runs.

## Note for the host app

Once this ships, the 3 unpublished suffixed posts can be corrected over MCP. The already-published one should keep its suffix: `BlogController` has no redirect layer, so renaming a live post breaks its URL with nothing catching it.