### PR TITLE
chore(ci): pin actions to commit SHAs, add dependabot and security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+If you discover any security related issues, please email manuk.minasyan1@gmail.com instead of using the issue tracker.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      npm:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Checkout gh-pages
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: gh-pages
           path: gh-pages
@@ -44,7 +44,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,33 @@ permissions:
   contents: read
 
 jobs:
+  actions-pinned:
+    name: Actions pinned to SHA
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Assert every third-party action is pinned to a full commit SHA
+        run: |
+          unpinned=$(grep -rhoE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^[:space:]]+' .github/workflows \
+            | sed -E 's/.*uses:[[:space:]]*//' \
+            | grep -v '^\./' \
+            | grep -vE '@[0-9a-f]{40}$' \
+            | sort -u || true)
+
+          if [ -n "$unpinned" ]; then
+            echo "Third-party actions must be pinned to a full 40-character commit SHA."
+            echo "Unpinned references:"
+            echo "$unpinned" | sed 's/^/  /'
+            exit 1
+          fi
+
+          echo "All third-party action references are pinned to a full commit SHA."
+
   tests:
     runs-on: ubuntu-latest
 
@@ -23,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl
@@ -41,8 +68,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.4'
           coverage: none

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: Zizmor
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Audit workflows
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2


### PR DESCRIPTION
Takes the package from **73.34 to 100** on [Plumb](https://plumbphp.dev/relaticle/ink), the audit behind the Filament plugin directory badge. Same treatment as Relaticle/flowforge#168 and #169.

## Plumb checks

| Check | Weight | Before | After |
|---|---|---|---|
| `security.actions-sha-pinned` | 8 | fail, 0 of 7 pinned | pass, 10 of 10 |
| `security.dependabot-or-renovate-configured` | 5 | fail, no updater | pass |
| `security.security-policy-present` | 3 | fail | pass |
| `security.dependency-update-cooldown` | 4 | *skipped* | pass, 7 days |

Security 51.52 to 100. Composite is `0.55*security + 0.30*maintenance + 0.15*ecosystem`, a formula I derived and validated to the second decimal against four scanned packages, so **73.34 to 100.00**.

Note the fourth row: `dependency-update-cooldown` was **not scored at all** because there was no updater to configure it on. Adding `dependabot.yml` pulls that check into the applicable set, so it has to be satisfied in the same change rather than becoming a new failure.

## Pins

7 refs resolved through the GitHub API, each SHA cross-checked against the tag object it dereferences to.

This repo had **no dependency updater at all**, which makes pinning a trap on its own: pinned SHAs with nothing to bump them are frozen forever, and Dependabot does not raise security alerts for SHA-pinned actions (["alerts are only generated for actions that use semantic versioning, not SHA versioning"](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts)). So the updater is not a nice-to-have here, it is what keeps the pins alive. The trailing version comments are what Dependabot reads to know the current version.

## zizmor

`zizmor 1.29.0` reports **no findings above low severity** on these workflows, before or after. `tests.yml` already declared `permissions: contents: read`. Nothing to fix, so nothing was changed beyond the pins.

The 4 remaining low findings are `artipacked` on checkouts in `deploy-docs.yml`, which pushes commits and needs its credentials.

## Regression guards

- `actions-pinned` job in `tests.yml` fails on any third-party `uses:` lacking a 40-hex SHA.
- New `zizmor.yml`, path-filtered to `.github/**`, results to the Security tab. Advisory by design; the hard gate stays the pin job.

## Verification

- Both existing workflows plus the two new ones parse as YAML.
- 10 of 10 third-party refs on a 40-hex SHA.
- `zizmor --min-severity medium .github/` reports `No findings to report.`

## Note on when the score moves

Plumb scores the **latest release tag**, not branch HEAD. Confirmed on packages where the two differ (`spatie/laravel-permission` is scored at tag `8.3.0` while `main` sits elsewhere). Merging alone will not move the badge; it needs a tag, then Plumb rescans on its 24h cadence.