### PR TITLE
fix(blog): show post covers uncropped in the listing thumbnail

### DIFF
--- a/resources/views/components/post-card.blade.php
+++ b/resources/views/components/post-card.blade.php
@@ -26,7 +26,7 @@
                 src="{{ asset('storage/' . $post->featured_image) }}"
                 alt="{{ $post->title }}"
                 loading="lazy"
-                class="w-24 h-24 object-cover rounded-lg shrink-0"
+                class="w-28 sm:w-40 aspect-video object-cover rounded-lg shrink-0"
             >
         @endif
     </div>


### PR DESCRIPTION
## Problem

Post covers are 1200x630, but the listing thumbnail renders them in a 96x96 `object-cover` square. `object-cover` crops to the center, so 48% of every cover is discarded and the title baked into the image is sliced on both sides.

On relaticle.com/blog, "How to Connect Claude to Your CRM with MCP" renders as "to Your CRM with MC".

## Fix

One class change in `post-card.blade.php`:

```diff
- class="w-24 h-24 object-cover rounded-lg shrink-0"
+ class="w-28 sm:w-40 aspect-video object-cover rounded-lg shrink-0"
```

`aspect-video` rather than an exact `aspect-[40/21]`: it matches the hero box `post-body.blade.php` already uses, stays sensible for consumers whose covers are not 1.9:1, and the 6.7% it trims from a 1200x630 image is the outer padding, never the title.

`related-posts` renders the same component, so post pages get the fix too.

## Verification

Rendered through a real consuming app (Relaticle) with three 1200x630 covers seeded locally and Tailwind rebuilt:

- desktop: 160x90, full cover visible, title legible
- mobile (390px): 112x63, text column still wraps to two excerpt lines
- checked in light and dark

Suite green: 198 passed.
