### PR TITLE
fix(docs): restore the docs build and gate it before merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,5 +24,10 @@ updates:
       npm:
         patterns:
           - "*"
+    ignore:
+      # docus declares a `better-sqlite3: 12.x` peer range. A major bump makes
+      # `npm ci` unresolvable. Drop this once docus widens the range.
+      - dependency-name: "better-sqlite3"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,22 +6,61 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/deploy-docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 concurrency:
-  group: deploy-docs
-  cancel-in-progress: false
+  group: deploy-docs-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: 'docs/package-lock.json'
+
+      - name: Install dependencies
+        working-directory: ./docs
+        run: npm ci
+
+      - name: Build documentation
+        working-directory: ./docs
+        run: npm run generate
+        env:
+          NUXT_APP_BASE_URL: /ink/
+          NUXT_SITE_URL: https://relaticle.github.io
+
+      - name: Upload built site
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docs-site
+          path: docs/.output/public
+          include-hidden-files: true
+          retention-days: 1
+
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - name: Checkout gh-pages
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -43,30 +82,17 @@ jobs:
             git commit -m "Init gh-pages"
           fi
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: Download built site
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: 'docs/package-lock.json'
-
-      - name: Install dependencies
-        working-directory: ./docs
-        run: npm ci
-
-      - name: Build documentation
-        working-directory: ./docs
-        run: npm run generate
-        env:
-          NUXT_APP_BASE_URL: /ink/
-          NUXT_SITE_URL: https://relaticle.github.io
+          name: docs-site
+          path: site
 
       - name: Deploy to gh-pages
         run: |
           cd gh-pages
-          # Remove everything except .git and .nojekyll
-          find . -maxdepth 1 ! -name '.git' ! -name '.nojekyll' ! -name '.' -exec rm -rf {} +
-          cp -r ../docs/.output/public/* .
+          find . -maxdepth 1 ! -name '.git' ! -name '.' -exec rm -rf {} +
+          cp -r ../site/. .
           touch .nojekyll
 
       - name: Commit and push

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,17 +1,17 @@
 {
-    "name": "flowforge-docs",
+    "name": "ink-docs",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "flowforge-docs",
+            "name": "ink-docs",
             "dependencies": {
                 "@nuxt/image": "^2.1.0",
                 "@nuxt/scripts": "^1.3.3",
                 "@nuxt/ui": "^4.10.0",
                 "@unhead/vue": "^2.0.17",
-                "better-sqlite3": "^13.0.3",
-                "docus": "*",
+                "better-sqlite3": "^12.4.1",
+                "docus": "^5.13.0",
                 "nuxt": "^4.5.2",
                 "typescript": "^5.9.2"
             },
@@ -20,81 +20,83 @@
             }
         },
         "node_modules/@ai-sdk/gateway": {
-            "version": "3.0.170",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.170.tgz",
-            "integrity": "sha512-w769X09is03N0uJYl82JbJzYiUN/XIOD2oWfYdSkiqoGHMephwXxcDcIO5jCVL7n5ylMBjZ0Ofso53A3ppY4YQ==",
+            "version": "4.0.68",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.68.tgz",
+            "integrity": "sha512-XKvZv6HFoMOWK64zXMaQatk4SxBzBDkGg7enXPWsCkxqPP4zDhFewOoBKasf3FPnZP9ceE+Yj3BgW925blAWtw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "3.0.15",
-                "@ai-sdk/provider-utils": "4.0.45",
+                "@ai-sdk/provider": "4.0.8",
+                "@ai-sdk/provider-utils": "5.0.33",
                 "@vercel/oidc": "3.2.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4.1.8"
             }
         },
         "node_modules/@ai-sdk/mcp": {
-            "version": "1.0.70",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.70.tgz",
-            "integrity": "sha512-rgbR+UZQF2DTsYUxgqTFjpFMaqXvQoGo9hS9q27qNpnNu5Pfv0qzUCg41YyED19cv3/LmF4tcpBY0YALsfdMxQ==",
+            "version": "2.0.40",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.40.tgz",
+            "integrity": "sha512-BMDJ50IHlMe/bSOQ9Pk46g/yybrN+TD3hz49ryMthBo0e+CQ54ZWOsU+x/Cl7zKYoZzRECD4CRm7iu76GVq17g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "3.0.15",
-                "@ai-sdk/provider-utils": "4.0.45",
-                "pkce-challenge": "^5.0.0"
+                "@ai-sdk/provider": "4.0.8",
+                "@ai-sdk/provider-utils": "5.0.33",
+                "cross-spawn": "^7.0.6",
+                "pkce-challenge": "^5.0.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4.1.8"
             }
         },
         "node_modules/@ai-sdk/provider": {
-            "version": "3.0.15",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.15.tgz",
-            "integrity": "sha512-XeZW1CcDF2GMbH4wejW6xBRI2QCOgnkVYUnxoeDadB1mf85riL2bMUeDoh+6gJ/r4mjNfzUPW8OjLjvwTP0u1Q==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.8.tgz",
+            "integrity": "sha512-aWO7iwhFUGf347tCwNGggggfmZigaSu7TF739IZSrWWABUp7zkb4Cr3fMqvBe5EIS7ABJJu3Cadn0g/zs1G0QQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "json-schema": "^0.4.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             }
         },
         "node_modules/@ai-sdk/provider-utils": {
-            "version": "4.0.45",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.45.tgz",
-            "integrity": "sha512-7u5B/E2uZmU65SlJhhQGFHZwRCN0xOz4HHtFc4sEGV9PHbX3fGiEiZBpc/SABay1dGeJgK3VD60rvLGoWdWPXA==",
+            "version": "5.0.33",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.33.tgz",
+            "integrity": "sha512-TfjJqJmRsQyxAlb+3hGmP1o1xLUIT79yhOgtJuTF4hqsB37IC3CufGsuFhU04EeTOg7R9iptQ6Bzm0MW0n/c3g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider": "3.0.15",
+                "@ai-sdk/provider": "4.0.8",
                 "@standard-schema/spec": "^1.1.0",
+                "@workflow/serde": "4.1.0",
                 "eventsource-parser": "^3.0.8",
-                "undici": "^5.29.0"
+                "undici": "^7.28.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4.1.8"
             }
         },
         "node_modules/@ai-sdk/vue": {
-            "version": "3.0.250",
-            "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-3.0.250.tgz",
-            "integrity": "sha512-2u6RGNr39p7/ewAIdZpEIz07MPPkVatpJDkT2GAJN0IoaRv+NofdTVnH69O1d9sB44FZBQd/Jz4vkv70t/t0Qw==",
+            "version": "4.0.84",
+            "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-4.0.84.tgz",
+            "integrity": "sha512-sOJ8dAhpijCBxRluU+rl8bxdfVoMKqHg0jmgvuiK3uIjODtJWZwn8+5UblIZKr2uZwRirAZvj+88w/Xaau+Skw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/provider-utils": "4.0.45",
-                "ai": "6.0.250",
-                "swrv": "^1.0.4"
+                "@ai-sdk/provider-utils": "5.0.33",
+                "ai": "7.0.84",
+                "swrv": "^1.2.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "vue": "^3.3.4"
@@ -627,16 +629,16 @@
             "license": "MIT"
         },
         "node_modules/@comark/vue": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@comark/vue/-/vue-0.4.0.tgz",
-            "integrity": "sha512-1o4BBBzVIcxCsPOfWUzcYqdnSSI+bCyldxzlrbATc5U+s40Hm+ls7UppYAHPyOqUQPpMZy2vbvD4ESe+PD5lgg==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/@comark/vue/-/vue-0.6.2.tgz",
+            "integrity": "sha512-ToRyzz4I96DjXtDgYOC1WnNWt0W6YgOcazuT8rVRMJRR86NXBLATnIWb3hdMM0/8lMaDz+DmlcpX5EN1hqsG0Q==",
             "dependencies": {
-                "comark": "^0.4.0"
+                "comark": "0.6.2"
             },
             "peerDependencies": {
                 "beautiful-mermaid": "^1.1.3",
-                "katex": "^0.16.45",
-                "shiki": "^4.0.0",
+                "katex": "^0.17.0",
+                "shiki": "^4.3.1",
                 "vue": "^3.5.0"
             },
             "peerDependenciesMeta": {
@@ -1277,15 +1279,6 @@
                 "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
-        "node_modules/@fastify/busboy": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-            "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@fingerprintjs/botd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@fingerprintjs/botd/-/botd-2.0.0.tgz",
@@ -1355,9 +1348,9 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
-            "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+            "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -1419,9 +1412,9 @@
             }
         },
         "node_modules/@iconify-json/lucide": {
-            "version": "1.2.123",
-            "resolved": "https://registry.npmjs.org/@iconify-json/lucide/-/lucide-1.2.123.tgz",
-            "integrity": "sha512-0CozmpKXEOEEhltrfT2zt+/t1hez67Y+hM2VJWoIcBKdBrb83VYuKf+b5A0QU9HfQm+RNn2GjFWlTOwi+Ss6IA==",
+            "version": "1.2.127",
+            "resolved": "https://registry.npmjs.org/@iconify-json/lucide/-/lucide-1.2.127.tgz",
+            "integrity": "sha512-7KuCCpkly00kefna4wEnCr8l2HFRkbn4mD4zRib8wCSbrBmnR/l57ExpU6j5jv/Bo+qHpWuHpDtcqceQ0ptArw==",
             "license": "ISC",
             "dependencies": {
                 "@iconify/types": "*"
@@ -1437,9 +1430,9 @@
             }
         },
         "node_modules/@iconify-json/vscode-icons": {
-            "version": "1.2.71",
-            "resolved": "https://registry.npmjs.org/@iconify-json/vscode-icons/-/vscode-icons-1.2.71.tgz",
-            "integrity": "sha512-sZ0NY91UNXgzBK8XX1FVmhiGyp06YHlQ3flnksT+eVqoVJ1TGLt4VCH42VClcytsihIkcfWDiepFU7bCN7cNIw==",
+            "version": "1.2.76",
+            "resolved": "https://registry.npmjs.org/@iconify-json/vscode-icons/-/vscode-icons-1.2.76.tgz",
+            "integrity": "sha512-gSu20bZiegbMFLSPHHtmliUJoOPhovTT77RNkMfr6u9ns5uC2bVZ4K5T7wUlywRAzQk4qgG7t4AULaucSsta4w==",
             "license": "MIT",
             "dependencies": {
                 "@iconify/types": "*"
@@ -1598,9 +1591,6 @@
             "cpu": [
                 "arm"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1616,9 +1606,6 @@
             "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1636,9 +1623,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1654,9 +1638,6 @@
             "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1674,9 +1655,6 @@
             "cpu": [
                 "s390x"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1692,9 +1670,6 @@
             "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -1712,9 +1687,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1731,9 +1703,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -1749,9 +1718,6 @@
             "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
             "cpu": [
                 "arm"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1775,9 +1741,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1799,9 +1762,6 @@
             "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
             "cpu": [
                 "ppc64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1825,9 +1785,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1849,9 +1806,6 @@
             "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -1875,9 +1829,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1900,9 +1851,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1924,9 +1872,6 @@
             "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2547,9 +2492,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3014,6 +2956,62 @@
                     "optional": true
                 },
                 "unplugin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/kit/node_modules/unplugin": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+            "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "picomatch": "^4.0.4",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "@farmfe/core": "*",
+                "@rspack/core": "*",
+                "bun-types-no-globals": "*",
+                "esbuild": "*",
+                "rolldown": "*",
+                "rollup": "*",
+                "unloader": "*",
+                "vite": "*",
+                "webpack": "*"
+            },
+            "peerDependenciesMeta": {
+                "@farmfe/core": {
+                    "optional": true
+                },
+                "@rspack/core": {
+                    "optional": true
+                },
+                "bun-types-no-globals": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "rollup": {
+                    "optional": true
+                },
+                "unloader": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                },
+                "webpack": {
                     "optional": true
                 }
             }
@@ -3498,9 +3496,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3516,9 +3511,6 @@
             "integrity": "sha512-ggGMQTN8Agwxp2WiLMpdY671dt0qTDJWiWlJeig3HnUwTnerRl0J2JdGVghWBeDcss2D9S2V2Js6dZHEiVabVA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -3536,9 +3528,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3554,9 +3543,6 @@
             "integrity": "sha512-A1x+PMWZmSGaFVOx2YeNTFau8uD+QO14/vLP4GrcuvUPs3+nBkUOjy9Lus86ftHsDojjYMbvBelmKc3F7Rv08g==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3574,9 +3560,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3592,9 +3575,6 @@
             "integrity": "sha512-2M1DPm/8w9I//YzFlFC9qXw+r2tJFh5CYwRlYTq2vUJQS7qoQftEDeCZ8EnN7KHtvSiXvYj8mZI5pR7DpXmcEw==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -3612,9 +3592,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3630,9 +3607,6 @@
             "integrity": "sha512-xRqpeI8U2sQQS1W5BMWRyMTxtagkuLG2dEWruet5lFsWHTvBth11/TpSaJatHdqVVwHN0q3uuoS9zRsGinq8hg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -4074,47 +4048,6 @@
                 }
             }
         },
-        "node_modules/@nuxt/ui/node_modules/unplugin-auto-import": {
-            "version": "21.1.0",
-            "resolved": "https://registry.npmjs.org/unplugin-auto-import/-/unplugin-auto-import-21.1.0.tgz",
-            "integrity": "sha512-EzrSqWIBulEqCuP7idADXH+tVKYrbwKlR5+r/lOWik0o+Ksny1kitmtryHGNSv7puzzORlcIwT/x2JStiszlHA==",
-            "license": "MIT",
-            "dependencies": {
-                "local-pkg": "^1.2.1",
-                "magic-string": "^1.1.0",
-                "picomatch": "^4.0.5",
-                "unimport": "^6.4.0",
-                "unplugin": "^3.3.0",
-                "unplugin-utils": "^0.3.2"
-            },
-            "engines": {
-                "node": ">=20.19.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "@nuxt/kit": "^4.0.0",
-                "@vueuse/core": "*"
-            },
-            "peerDependenciesMeta": {
-                "@nuxt/kit": {
-                    "optional": true
-                },
-                "@vueuse/core": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@nuxt/ui/node_modules/unplugin-auto-import/node_modules/magic-string": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.1.tgz",
-            "integrity": "sha512-qFemKPzc3ttrYVaMmnSkGtGc5nE6Ncl4bj7c9IE6C9OUIRXjf6PzJ+UZ1xhVIjYc7dolHq3qKzpAJPZUbvNj+A==",
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.5"
-            }
-        },
         "node_modules/@nuxt/vite-builder": {
             "version": "4.5.2",
             "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-4.5.2.tgz",
@@ -4175,6 +4108,491 @@
                 "rollup-plugin-visualizer": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+            "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/android-arm": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+            "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/android-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+            "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/android-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+            "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+            "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+            "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+            "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-arm": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+            "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+            "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+            "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+            "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+            "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+            "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+            "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+            "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+            "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+            "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+            "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+            "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+            "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/win32-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+            "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/esbuild": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+            "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.2",
+                "@esbuild/android-arm": "0.28.2",
+                "@esbuild/android-arm64": "0.28.2",
+                "@esbuild/android-x64": "0.28.2",
+                "@esbuild/darwin-arm64": "0.28.2",
+                "@esbuild/darwin-x64": "0.28.2",
+                "@esbuild/freebsd-arm64": "0.28.2",
+                "@esbuild/freebsd-x64": "0.28.2",
+                "@esbuild/linux-arm": "0.28.2",
+                "@esbuild/linux-arm64": "0.28.2",
+                "@esbuild/linux-ia32": "0.28.2",
+                "@esbuild/linux-loong64": "0.28.2",
+                "@esbuild/linux-mips64el": "0.28.2",
+                "@esbuild/linux-ppc64": "0.28.2",
+                "@esbuild/linux-riscv64": "0.28.2",
+                "@esbuild/linux-s390x": "0.28.2",
+                "@esbuild/linux-x64": "0.28.2",
+                "@esbuild/netbsd-arm64": "0.28.2",
+                "@esbuild/netbsd-x64": "0.28.2",
+                "@esbuild/openbsd-arm64": "0.28.2",
+                "@esbuild/openbsd-x64": "0.28.2",
+                "@esbuild/openharmony-arm64": "0.28.2",
+                "@esbuild/sunos-x64": "0.28.2",
+                "@esbuild/win32-arm64": "0.28.2",
+                "@esbuild/win32-ia32": "0.28.2",
+                "@esbuild/win32-x64": "0.28.2"
             }
         },
         "node_modules/@nuxt/vite-builder/node_modules/escape-string-regexp": {
@@ -4325,9 +4743,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4347,9 +4762,6 @@
             "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -4371,9 +4783,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -4393,9 +4802,6 @@
             "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -4775,9 +5181,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4793,9 +5196,6 @@
             "integrity": "sha512-jMkS/EztNW34HKsXIaT/SoHcmtocq/vWhwFOVduF9kduuuRIVwfwQ6uxzIO+qPKSXdd2TXt54of0BJ2zFMXnmw==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -4813,9 +5213,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4831,9 +5228,6 @@
             "integrity": "sha512-oh80w+7RuiO5gBp9Jnoa/H8Qlt3JsHL2MkW+0dwEdlDMdslVZX/YsekSK6EeyEenY66/mhCfypsNATQ7Ph3qlQ==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -4851,9 +5245,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4869,9 +5260,6 @@
             "integrity": "sha512-3wnwk/l1CvszVE5TJR1wSl/zSEfydRqrNhn6s7Vr9IzSJpUQIroqVsIoPARHRFA+FQwkxAFDAHDAasa7v8OobQ==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -4889,9 +5277,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4907,9 +5292,6 @@
             "integrity": "sha512-SkGV1nKw40roEc94pv5EaaeH2ay14G6+roe8Q0wIUC1LcEKxzKW921h7+ZuZX0D3q2Mb/7aSFmxEVqnko3lPRw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -5200,6 +5582,51 @@
                 }
             }
         },
+        "node_modules/@nuxtjs/mcp-toolkit": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/mcp-toolkit/-/mcp-toolkit-0.19.0.tgz",
+            "integrity": "sha512-sKTlK+x2WXPPoOFQ6DkhN+3KDM0IeTms8/T3mvuDV6GuDxKASqqAKlIkkoGQ266+x/YvT1XPChGwQ7ROKqEASQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@modelcontextprotocol/sdk": "^1.30.0",
+                "@nuxt/kit": "^4.5.2",
+                "@vitejs/plugin-vue": "^6.0.8",
+                "tinyglobby": "^0.2.17",
+                "vite-plugin-singlefile": "^2.3.3"
+            },
+            "peerDependencies": {
+                "@vue/compiler-sfc": "^3.5.41",
+                "agents": ">=0.20.1",
+                "h3": ">=1.15.11",
+                "secure-exec": ">=0.3.3",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+                "vue": "^3.5.41",
+                "zod": "^4.1.13"
+            },
+            "peerDependenciesMeta": {
+                "@vue/compiler-sfc": {
+                    "optional": true
+                },
+                "agents": {
+                    "optional": true
+                },
+                "h3": {
+                    "optional": false
+                },
+                "secure-exec": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                },
+                "vue": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": false
+                }
+            }
+        },
         "node_modules/@nuxtjs/mdc": {
             "version": "0.22.2",
             "resolved": "https://registry.npmjs.org/@nuxtjs/mdc/-/mdc-0.22.2.tgz",
@@ -5253,9 +5680,9 @@
             }
         },
         "node_modules/@nuxtjs/robots": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-6.1.4.tgz",
-            "integrity": "sha512-EQmcyegctRSrKfLnl5YHzIYEt6h3jSWj8jtzlfcr79WrZOv/i5eLcZm/ewhelmJVkkm5BB/UPcam52JK4i7u1w==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/robots/-/robots-6.2.0.tgz",
+            "integrity": "sha512-+y8BRDWOkSMofe0ewOlVQm6+VFd4Qh/I8kh9z/++VwfPlDtrU6BDhoobJ18eVDaMkf8gJl12dwKZziK8yU4c/g==",
             "license": "MIT",
             "dependencies": {
                 "@fingerprintjs/botd": "^2.0.0",
@@ -5263,8 +5690,8 @@
                 "consola": "^3.4.2",
                 "defu": "^6.1.7",
                 "h3": "^1.15.11",
-                "nuxt-site-config": "^4.2.0",
-                "nuxtseo-shared": "^5.3.10",
+                "nuxt-site-config": "^4.2.3",
+                "nuxtseo-shared": "^5.3.14",
                 "pathe": "^2.0.3",
                 "pkg-types": "^2.3.1",
                 "ufo": "^1.6.4"
@@ -5281,13 +5708,308 @@
                 }
             }
         },
-        "node_modules/@opentelemetry/api": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-            "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-            "license": "Apache-2.0",
+        "node_modules/@oxc-parser/binding-android-arm-eabi": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.143.0.tgz",
+            "integrity": "sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
             "engines": {
-                "node": ">=8.0.0"
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-android-arm64": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.143.0.tgz",
+            "integrity": "sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-darwin-arm64": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.143.0.tgz",
+            "integrity": "sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-darwin-x64": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.143.0.tgz",
+            "integrity": "sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-freebsd-x64": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.143.0.tgz",
+            "integrity": "sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.143.0.tgz",
+            "integrity": "sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.143.0.tgz",
+            "integrity": "sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.143.0.tgz",
+            "integrity": "sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.143.0.tgz",
+            "integrity": "sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.143.0.tgz",
+            "integrity": "sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.143.0.tgz",
+            "integrity": "sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.143.0.tgz",
+            "integrity": "sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.143.0.tgz",
+            "integrity": "sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.143.0.tgz",
+            "integrity": "sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-linux-x64-musl": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.143.0.tgz",
+            "integrity": "sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-openharmony-arm64": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.143.0.tgz",
+            "integrity": "sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.143.0.tgz",
+            "integrity": "sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.143.0.tgz",
+            "integrity": "sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.143.0.tgz",
+            "integrity": "sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/@oxc-project/types": {
@@ -5418,9 +6140,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5436,9 +6155,6 @@
             "integrity": "sha512-aUUptri02E4nqkUvyA+2oYkmU20pYnHIpNLPZOgom0kAa0Fx9X6QFKqKm1MopyucWolQ9XTgCK2PrupSSBdCdQ==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -5456,9 +6172,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5474,9 +6187,6 @@
             "integrity": "sha512-P6XVhw+MJsjeliWJ6BBKdC0HU1VEiwMRHtqUADK+jK5wiqgzt3/JhIcMuRLzBPYfnOujLpe+fm63yEzKUIAcSA==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -5494,9 +6204,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5512,9 +6219,6 @@
             "integrity": "sha512-r2Jk0vfcnHnkPOjLnWvpGVTFcYDirGICBJYraCkWeplhPZ2Sgg9GvDVgah9VFOHRZVtK6XQynELP9A8EB/Ne0Q==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -5532,9 +6236,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5550,9 +6251,6 @@
             "integrity": "sha512-y+9FbVRBhUtHBVn0xHiVcaNHkoRudIhlKhRk1+CclE1uGD6af3xznTjCOrKGB7HZ2SzlCWLZwQGm/KERpUjX1w==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -5756,34 +6454,6 @@
             "integrity": "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==",
             "license": "MIT"
         },
-        "node_modules/@quansync/fs": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz",
-            "integrity": "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==",
-            "license": "MIT",
-            "dependencies": {
-                "quansync": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sxzz"
-            }
-        },
-        "node_modules/@quansync/fs/node_modules/quansync": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
-            "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/antfu"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/sxzz"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/@rolldown/binding-android-arm64": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
@@ -5871,9 +6541,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5889,9 +6556,6 @@
             "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -5909,9 +6573,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5927,9 +6588,6 @@
             "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -5947,9 +6605,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5965,9 +6620,6 @@
             "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6313,9 +6965,6 @@
             "cpu": [
                 "arm"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6328,9 +6977,6 @@
             "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
             "cpu": [
                 "arm"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6345,9 +6991,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6360,9 +7003,6 @@
             "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6377,9 +7017,6 @@
             "cpu": [
                 "loong64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6392,9 +7029,6 @@
             "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
             "cpu": [
                 "loong64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6409,9 +7043,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6424,9 +7055,6 @@
             "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
             "cpu": [
                 "ppc64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6441,9 +7069,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6456,9 +7081,6 @@
             "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6473,9 +7095,6 @@
             "cpu": [
                 "s390x"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6489,9 +7108,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6504,9 +7120,6 @@
             "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6940,9 +7553,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6958,9 +7568,6 @@
             "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6978,9 +7585,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6996,9 +7600,6 @@
             "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -7158,31 +7759,39 @@
             }
         },
         "node_modules/@takumi-rs/core": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core/-/core-1.8.7.tgz",
-            "integrity": "sha512-Ia8I3vg0VAQPnzHiYRrd18UgZbIj3X0zMwWMjuTm3yb2TBH1988lPwnnlf+eAfYMwZrutNiXLLtgEnkzsm2gMw==",
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core/-/core-2.13.2.tgz",
+            "integrity": "sha512-HEWNqACqBy+nvisWr79LQdOdXEuw58dvOyb9CFVSQ0GDAe/CP4PqFGXbnPc/MGCGpdx4WfqyekqohL3CqCL10g==",
             "license": "(MIT OR Apache-2.0)",
             "dependencies": {
-                "@takumi-rs/helpers": "1.8.7"
+                "@takumi-rs/helpers": "2.13.2"
             },
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             },
             "optionalDependencies": {
-                "@takumi-rs/core-darwin-arm64": "1.8.7",
-                "@takumi-rs/core-darwin-x64": "1.8.7",
-                "@takumi-rs/core-linux-arm64-gnu": "1.8.7",
-                "@takumi-rs/core-linux-arm64-musl": "1.8.7",
-                "@takumi-rs/core-linux-x64-gnu": "1.8.7",
-                "@takumi-rs/core-linux-x64-musl": "1.8.7",
-                "@takumi-rs/core-win32-arm64-msvc": "1.8.7",
-                "@takumi-rs/core-win32-x64-msvc": "1.8.7"
+                "@takumi-rs/core-darwin-arm64": "2.13.2",
+                "@takumi-rs/core-darwin-x64": "2.13.2",
+                "@takumi-rs/core-linux-arm64-gnu": "2.13.2",
+                "@takumi-rs/core-linux-arm64-musl": "2.13.2",
+                "@takumi-rs/core-linux-x64-gnu": "2.13.2",
+                "@takumi-rs/core-linux-x64-musl": "2.13.2",
+                "@takumi-rs/core-win32-arm64-msvc": "2.13.2",
+                "@takumi-rs/core-win32-x64-msvc": "2.13.2"
+            },
+            "peerDependencies": {
+                "csstype": "*"
+            },
+            "peerDependenciesMeta": {
+                "csstype": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@takumi-rs/core-darwin-arm64": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-darwin-arm64/-/core-darwin-arm64-1.8.7.tgz",
-            "integrity": "sha512-an8vc2B/Qf9vo3uwDmJ6WKazpMBpDruRy/kXr+x98GfIkzMHDEUy+9EgNfUYxprtZo49cJruXrVwzxsqqW+1tA==",
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-darwin-arm64/-/core-darwin-arm64-2.13.2.tgz",
+            "integrity": "sha512-1PefY+zWxuvg9KkOOFXhmDfPPsPQd6fKiIckbKBO2LbdxCM1NRTICmfMW13SYkiCFjNQCMS8LeFxupsrdf/TfQ==",
             "cpu": [
                 "arm64"
             ],
@@ -7192,13 +7801,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-darwin-x64": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-darwin-x64/-/core-darwin-x64-1.8.7.tgz",
-            "integrity": "sha512-q0xQxmb4y4EwYK3ILMBvWvqLGX8gxsqcEas0zOwNbPnxBLTQFF8KVH4jXaKXLUFwj020lu8nsf1BNvLIkJMo3Q==",
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-darwin-x64/-/core-darwin-x64-2.13.2.tgz",
+            "integrity": "sha512-uTevS9c74wB98NlmU0lhpNH+rhtNOPp4pi+B5Z21ACsjAwacVS3i0oFBhkUTYhng7ec1iGxPMJzt3ocjEe8reg==",
             "cpu": [
                 "x64"
             ],
@@ -7208,18 +7817,15 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-linux-arm64-gnu": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.8.7.tgz",
-            "integrity": "sha512-uZ6l792M4Mc06XG+m+8RarTgdR5o1ZLjncULKUEPAw3nBKhRbJ50Re3aLM4n4+p25iOj1oL9QwEZRcaJn8u/Ag==",
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-arm64-gnu/-/core-linux-arm64-gnu-2.13.2.tgz",
+            "integrity": "sha512-ovSzAJ/S5KFwELiSoomjWpWjjGkidpj1pu1pNuP4bVQJ0xruLAUqMiYaPe2PNV3QIPyeWqO0wI1NfhQ7cCThkQ==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "(MIT OR Apache-2.0)",
             "optional": true,
@@ -7227,18 +7833,15 @@
                 "linux"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-linux-arm64-musl": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-arm64-musl/-/core-linux-arm64-musl-1.8.7.tgz",
-            "integrity": "sha512-akVy80ztI2as/b0n0EVCfHNKhibp+Od4ioP49PtX2rQMi6KDtqv3aoCIjaBls8oxzv+4x77/2U9fsWIO2XZQjg==",
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-arm64-musl/-/core-linux-arm64-musl-2.13.2.tgz",
+            "integrity": "sha512-9jN6nN9XFw+cKPNc2Fb3YrTVZZVV7eWdQuo+nbWMK6UVikc9g0r/Xazuy58HVbDtOmr0wpJ1SnKzrVHFa0bC9g==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "(MIT OR Apache-2.0)",
             "optional": true,
@@ -7246,18 +7849,15 @@
                 "linux"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-linux-x64-gnu": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-x64-gnu/-/core-linux-x64-gnu-1.8.7.tgz",
-            "integrity": "sha512-SV1YesGs/HfC1CMpSF5SqS6KbL4hDLvD2m54JcfB+X/0xatmo/CS2XleqoIXhSmR+95X8Of5g2vg1a4TAdpcug==",
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-x64-gnu/-/core-linux-x64-gnu-2.13.2.tgz",
+            "integrity": "sha512-ScIjE6fZkL5FN6Abru1EelYaeyjsSH5PBGRYQOZ5mI6LyIm4dfEsfILWTOMqUGAuBW5KcU8ScDQg8L6eeuHX6A==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "(MIT OR Apache-2.0)",
             "optional": true,
@@ -7265,18 +7865,15 @@
                 "linux"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-linux-x64-musl": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-x64-musl/-/core-linux-x64-musl-1.8.7.tgz",
-            "integrity": "sha512-zprYQ/ivPDmYX4tFaONiAzoDJNTANA3kqfIe7SMHZ2YhkfEhYnr3PE3XtBytgB4W/VlTc9WQLyD77SKwPnPuFw==",
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-linux-x64-musl/-/core-linux-x64-musl-2.13.2.tgz",
+            "integrity": "sha512-2KGSKY6y6eqif4ED3zCKEfdwmxP1VQtN+d9CBfHh1fCH3u5Hf0IIudpPVQyqzHHARp3xtS++wD1eqNndpwV2AQ==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "(MIT OR Apache-2.0)",
             "optional": true,
@@ -7284,13 +7881,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-win32-arm64-msvc": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.8.7.tgz",
-            "integrity": "sha512-2S5YcgIj/c0E3sLzWDcxzlXoPvEjR2xC1v7yODe0CvimlRx95Df6rJ9idTS6E1KNUjDaTfqxTr8Ud4gWqYrrPg==",
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-win32-arm64-msvc/-/core-win32-arm64-msvc-2.13.2.tgz",
+            "integrity": "sha512-Wck0eWTdpRATFLuOTGybOvuZnDLVjQ5xmGE8+2hI0DzZPQTSfmOyW+6Rx+4xOjKT7GW/r9qaeGtNFtznqJF7kg==",
             "cpu": [
                 "arm64"
             ],
@@ -7300,13 +7897,13 @@
                 "win32"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/core-win32-x64-msvc": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/core-win32-x64-msvc/-/core-win32-x64-msvc-1.8.7.tgz",
-            "integrity": "sha512-sooiM6fL0JN597ciNAFVp9F7YxCW+8hXpwu/7wRMRo0TGQ/KMi1Y94tf1FUu2csCHN0pgy9a3y09y8+qnw3FTw==",
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/core-win32-x64-msvc/-/core-win32-x64-msvc-2.13.2.tgz",
+            "integrity": "sha512-+/OeGaxpoYWQFoTKWGexcZX8Lxo4b6D14KoA1gW3H1N7Wo8rB6yK9mtiDo17OTzbMqJXLZD0ng5mIbYvCvSnnw==",
             "cpu": [
                 "x64"
             ],
@@ -7316,23 +7913,26 @@
                 "win32"
             ],
             "engines": {
-                "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+                "node": ">=18"
             }
         },
         "node_modules/@takumi-rs/helpers": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/@takumi-rs/helpers/-/helpers-1.8.7.tgz",
-            "integrity": "sha512-5dSR9W8msQ7Asp4TCvUUB9Bt8yLgIc2ASjWtEG4Jn9xSuAVJLWFZ21Xl8HShW5GE6SV5aCCM9BL0NA9YuBWIJw==",
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@takumi-rs/helpers/-/helpers-2.13.2.tgz",
+            "integrity": "sha512-3GeoDLq30EgOW+fQlE14AQ2Ya3vmjRoKaqOQo6vlFGh7OMeRL0odDGI7AbWTgjpVWIE2tsyS/77Si2pFtOtVxg==",
             "license": "(MIT OR Apache-2.0)",
+            "engines": {
+                "node": ">=18"
+            },
             "peerDependencies": {
-                "react": "^19.2.5",
-                "react-dom": "^18.0.0 || ^19.0.0"
+                "preact": "^10.0.0",
+                "react": "^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
-                "react": {
+                "preact": {
                     "optional": true
                 },
-                "react-dom": {
+                "react": {
                     "optional": true
                 }
             }
@@ -8240,30 +8840,6 @@
             "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
             "license": "MIT"
         },
-        "node_modules/@unocss/config": {
-            "version": "66.7.5",
-            "resolved": "https://registry.npmjs.org/@unocss/config/-/config-66.7.5.tgz",
-            "integrity": "sha512-dkPl9glhEahJ+Xoja5ZseKKnH+vZaeaKQzg8b0otcKcPPNrHQgu1nu3QgfeOjnXOGrjZIotHwUeVtt4ZA2Skgg==",
-            "license": "MIT",
-            "dependencies": {
-                "@unocss/core": "66.7.5",
-                "colorette": "^2.0.20",
-                "consola": "^3.4.2",
-                "unconfig": "^7.5.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/@unocss/core": {
-            "version": "66.7.5",
-            "resolved": "https://registry.npmjs.org/@unocss/core/-/core-66.7.5.tgz",
-            "integrity": "sha512-UdJb8MiMywcau8QrWEVgUAz0kvoFHyR+sACwYCgmBh/BpKJGyR/zw/Ys3wvysbm0f+i/20VGBex/QQxYVlzdyQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
         "node_modules/@vercel/nft": {
             "version": "1.10.2",
             "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.10.2.tgz",
@@ -8761,6 +9337,12 @@
             "integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==",
             "license": "MIT"
         },
+        "node_modules/@workflow/serde": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+            "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+            "license": "Apache-2.0"
+        },
         "node_modules/abbrev": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
@@ -8835,18 +9417,17 @@
             }
         },
         "node_modules/ai": {
-            "version": "6.0.250",
-            "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.250.tgz",
-            "integrity": "sha512-uMaJoCubOqrtdTB7N72/yf1qdyKhlW/WPhTP6lmn4DRISE1qmiPT4z/DlflzQu5i2s9tqpe0LQ3WMsx7Fv5vKQ==",
+            "version": "7.0.84",
+            "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.84.tgz",
+            "integrity": "sha512-znHNBWADOy79k8EK7636kDm5LmnjF4tMzegC2TfmlLDobDZbs0z0OXD2sxtH3eDTp5Re+pJQESvjinWJ6+kadQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ai-sdk/gateway": "3.0.170",
-                "@ai-sdk/provider": "3.0.15",
-                "@ai-sdk/provider-utils": "4.0.45",
-                "@opentelemetry/api": "^1.9.0"
+                "@ai-sdk/gateway": "4.0.68",
+                "@ai-sdk/provider": "4.0.8",
+                "@ai-sdk/provider-utils": "5.0.33"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "zod": "^3.25.76 || ^4.1.8"
@@ -9212,24 +9793,17 @@
             }
         },
         "node_modules/better-sqlite3": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
-            "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+            "version": "12.11.1",
+            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+            "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "node-addon-api": "^8.0.0"
+                "bindings": "^1.5.0",
+                "prebuild-install": "^7.1.1"
             },
             "engines": {
-                "node": ">=22"
-            }
-        },
-        "node_modules/better-sqlite3/node_modules/node-addon-api": {
-            "version": "8.9.1",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
-            "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
-            "license": "MIT",
-            "engines": {
-                "node": "^18 || ^20 || >= 21"
+                "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
             }
         },
         "node_modules/bindings": {
@@ -9248,6 +9822,55 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/bl/node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+            }
+        },
+        "node_modules/bl/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/body-parser": {
@@ -9275,9 +9898,9 @@
             }
         },
         "node_modules/body-parser/node_modules/content-type": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -9676,12 +10299,6 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
         },
-        "node_modules/colorette": {
-            "version": "2.0.20",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-            "license": "MIT"
-        },
         "node_modules/colortranslator": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/colortranslator/-/colortranslator-5.0.0.tgz",
@@ -9689,26 +10306,30 @@
             "license": "Apache-2.0"
         },
         "node_modules/comark": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/comark/-/comark-0.4.0.tgz",
-            "integrity": "sha512-s+wZc9FDgxJDxS3oLhDhthuc8EFggd7oEQaGKEFSw/UbECEwM3qMgW/T3dk6eoNTuy+PNSAyPQtjyKZJfudlbA==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/comark/-/comark-0.6.2.tgz",
+            "integrity": "sha512-hlWa7KlGPfRxovQavnHZlLlTUKrfwE7/o4ewCY0FzqFtRvVT8VdslrumQwELIiK9utsurpoSWCBFj1yVMtDOtw==",
             "license": "MIT",
             "dependencies": {
                 "entities": "^8.0.0",
                 "htmlparser2": "^12.0.0",
-                "js-yaml": "^4.1.1",
-                "markdown-exit": "1.0.0-beta.9"
+                "js-yaml": "^5.2.1",
+                "markdown-exit": "1.1.0-beta.2"
             },
             "peerDependencies": {
                 "beautiful-mermaid": "^1.1.3",
-                "katex": "^0.16.45",
-                "shiki": "^4.0.0"
+                "katex": "^0.17.0",
+                "rangi": "^2.2.0",
+                "shiki": "^4.3.1"
             },
             "peerDependenciesMeta": {
                 "beautiful-mermaid": {
                     "optional": true
                 },
                 "katex": {
+                    "optional": true
+                },
+                "rangi": {
                     "optional": true
                 },
                 "shiki": {
@@ -9726,6 +10347,28 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/comark/node_modules/js-yaml": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+            "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.mjs"
             }
         },
         "node_modules/comma-separated-tokens": {
@@ -10102,15 +10745,6 @@
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "license": "MIT"
         },
-        "node_modules/culori": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/culori/-/culori-4.0.2.tgz",
-            "integrity": "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==",
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            }
-        },
         "node_modules/db0": {
             "version": "0.3.4",
             "resolved": "https://registry.npmjs.org/db0/-/db0-0.3.4.tgz",
@@ -10188,6 +10822,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/deep-is": {
@@ -10356,44 +10999,44 @@
             "license": "MIT"
         },
         "node_modules/docus": {
-            "version": "5.12.3",
-            "resolved": "https://registry.npmjs.org/docus/-/docus-5.12.3.tgz",
-            "integrity": "sha512-v5CF/Ta3+aAzuUKwPsFwSSCACXh9QRWbBZENwUyheajATnPrSnql+oHbDzANM+GBwDvmPpCBhzHsjKrdZZR0cw==",
+            "version": "5.13.0",
+            "resolved": "https://registry.npmjs.org/docus/-/docus-5.13.0.tgz",
+            "integrity": "sha512-RWAFlYfdDedJrjmFSmrr7Vcq939i2kmQklusDgIatWIm2gSPZUvXpqlNiyR7V5UYKhZl4fMzjlTtfV5rJiMPnQ==",
             "license": "MIT",
             "dependencies": {
-                "@ai-sdk/gateway": "^3.0.133",
-                "@ai-sdk/mcp": "^1.0.52",
-                "@ai-sdk/vue": "^3.0.208",
-                "@comark/vue": "^0.4.0",
-                "@iconify-json/lucide": "^1.2.114",
-                "@iconify-json/simple-icons": "^1.2.87",
-                "@iconify-json/vscode-icons": "^1.2.59",
-                "@nuxt/content": "^3.14.0",
-                "@nuxt/image": "^2.0.0",
-                "@nuxt/kit": "^4.4.8",
-                "@nuxt/ui": "^4.9.0",
-                "@nuxtjs/i18n": "^10.4.0",
-                "@nuxtjs/mcp-toolkit": "^0.17.2",
-                "@nuxtjs/mdc": "^0.22.0",
-                "@nuxtjs/robots": "^6.1.1",
-                "@shikijs/core": "^4.2.0",
-                "@shikijs/engine-javascript": "^4.2.0",
-                "@shikijs/langs": "^4.2.0",
-                "@shikijs/stream": "^4.2.0",
-                "@shikijs/themes": "^4.2.0",
-                "@takumi-rs/core": "^1.8.7",
-                "@vueuse/core": "^14.3.0",
-                "ai": "^6.0.208",
+                "@ai-sdk/gateway": "^4.0.62",
+                "@ai-sdk/mcp": "^2.0.36",
+                "@ai-sdk/vue": "^4.0.77",
+                "@comark/vue": "^0.6.2",
+                "@iconify-json/lucide": "^1.2.125",
+                "@iconify-json/simple-icons": "^1.2.93",
+                "@iconify-json/vscode-icons": "^1.2.74",
+                "@nuxt/content": "^3.15.2",
+                "@nuxt/image": "^2.1.0",
+                "@nuxt/kit": "^4.5.2",
+                "@nuxt/ui": "^4.11.0",
+                "@nuxtjs/i18n": "^10.6.0",
+                "@nuxtjs/mcp-toolkit": "^0.19.0",
+                "@nuxtjs/mdc": "^0.22.2",
+                "@nuxtjs/robots": "^6.2.0",
+                "@shikijs/core": "^4.4.3",
+                "@shikijs/engine-javascript": "^4.4.3",
+                "@shikijs/langs": "^4.4.3",
+                "@shikijs/stream": "^4.4.3",
+                "@shikijs/themes": "^4.4.3",
+                "@takumi-rs/core": "^2.10.0",
+                "@vueuse/core": "^14.4.0",
+                "ai": "^7.0.77",
                 "defu": "^6.1.7",
-                "exsolve": "^1.1.0",
+                "exsolve": "^1.1.1",
                 "git-url-parse": "^16.1.0",
-                "motion-v": "^2.3.0",
+                "motion-v": "^2.4.0",
                 "nuxt-llms": "^0.2.0",
-                "nuxt-og-image": "~6.6.0",
+                "nuxt-og-image": "~6.7.8",
                 "pathe": "^2.0.3",
                 "pkg-types": "^2.3.1",
                 "scule": "^1.3.0",
-                "tailwindcss": "^4.3.1",
+                "tailwindcss": "^4.3.3",
                 "ufo": "^1.6.4",
                 "yaml": "^2.9.0",
                 "zod": "^4.4.3",
@@ -10404,35 +11047,484 @@
                 "nuxt": "4.x"
             }
         },
-        "node_modules/docus/node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-            "license": "MIT",
+        "node_modules/docus/node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
             "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.2.4"
             }
         },
-        "node_modules/docus/node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-            "license": "MIT",
+        "node_modules/docus/node_modules/@img/sharp-darwin-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
             "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.2.4"
             }
         },
-        "node_modules/docus/node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-            "license": "MIT",
+        "node_modules/docus/node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
             "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-libvips-linux-ppc64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-linux-arm": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.2.4"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-linux-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.2.4"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-linux-ppc64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.2.4"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-linux-s390x": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.2.4"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-linux-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.2.4"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-wasm32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
-                "tslib": "^2.4.0"
+                "@emnapi/runtime": "^1.7.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-win32-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-win32-ia32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/docus/node_modules/@img/sharp-win32-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/docus/node_modules/@nuxt/content": {
@@ -10531,435 +11623,537 @@
                 "url": "https://github.com/sponsors/colinhacks"
             }
         },
-        "node_modules/docus/node_modules/@nuxtjs/mcp-toolkit": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@nuxtjs/mcp-toolkit/-/mcp-toolkit-0.17.2.tgz",
-            "integrity": "sha512-8/4d/QTc6KfUTml8IlQ2mrznszQcBCribciz+wogbCL+YCrKjqbzSz8azaQ8MvqdSHk1h3acTL4qdkLNLurLlA==",
+        "node_modules/docus/node_modules/@nuxt/ui": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-4.11.0.tgz",
+            "integrity": "sha512-gDs67/fWk3kipcEV4Pc5h1VnZD1glfWfINmJU7s3qpkxxRTkfkPxnUszXG664whNWcoqucS1WgZ/rNjZa3pTMw==",
             "license": "MIT",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.29.0",
-                "@nuxt/kit": "^4.4.6",
-                "@vitejs/plugin-vue": "^6.0.7",
-                "tinyglobby": "^0.2.16",
-                "vite-plugin-singlefile": "^2.3.3"
+                "@floating-ui/dom": "^1.8.0",
+                "@iconify/vue": "^5.0.1",
+                "@internationalized/date": "^3.12.3",
+                "@internationalized/number": "^3.6.7",
+                "@nuxt/fonts": "^0.14.0",
+                "@nuxt/icon": "^2.5.0",
+                "@nuxt/kit": "^4.5.2",
+                "@nuxt/schema": "^4.5.2",
+                "@nuxtjs/color-mode": "^4.0.1",
+                "@standard-schema/spec": "^1.1.0",
+                "@tailwindcss/postcss": "^4.3.3",
+                "@tailwindcss/vite": "^4.3.3",
+                "@tanstack/vue-table": "^8.21.3",
+                "@tanstack/vue-virtual": "^3.13.35",
+                "@tiptap/core": "^3.29.2",
+                "@tiptap/extension-bubble-menu": "^3.29.2",
+                "@tiptap/extension-code": "^3.29.2",
+                "@tiptap/extension-collaboration": "^3.29.2",
+                "@tiptap/extension-drag-handle": "^3.29.2",
+                "@tiptap/extension-drag-handle-vue-3": "^3.29.2",
+                "@tiptap/extension-floating-menu": "^3.29.2",
+                "@tiptap/extension-horizontal-rule": "^3.29.2",
+                "@tiptap/extension-image": "^3.29.2",
+                "@tiptap/extension-mention": "^3.29.2",
+                "@tiptap/extension-node-range": "^3.29.2",
+                "@tiptap/extension-placeholder": "^3.29.2",
+                "@tiptap/markdown": "^3.29.2",
+                "@tiptap/pm": "^3.29.2",
+                "@tiptap/starter-kit": "^3.29.2",
+                "@tiptap/suggestion": "^3.29.2",
+                "@tiptap/vue-3": "^3.29.2",
+                "@unhead/vue": "^3.3.2",
+                "@vueuse/core": "^14.4.0",
+                "@vueuse/integrations": "^14.4.0",
+                "@vueuse/shared": "^14.4.0",
+                "colortranslator": "^5.0.0",
+                "consola": "^3.4.2",
+                "defu": "^6.1.7",
+                "embla-carousel-auto-height": "^8.6.0",
+                "embla-carousel-auto-scroll": "^8.6.0",
+                "embla-carousel-autoplay": "^8.6.0",
+                "embla-carousel-class-names": "^8.6.0",
+                "embla-carousel-fade": "^8.6.0",
+                "embla-carousel-vue": "^8.6.0",
+                "embla-carousel-wheel-gestures": "^8.1.0",
+                "fuse.js": "^7.5.0",
+                "hookable": "^6.1.1",
+                "knitwork": "^1.3.0",
+                "magic-string": "^1.2.0",
+                "mlly": "^1.8.2",
+                "motion-v": "^2.4.0",
+                "ohash": "^2.0.12",
+                "pathe": "^2.0.3",
+                "reka-ui": "2.10.3",
+                "scule": "^1.3.0",
+                "tailwind-merge": "^3.6.0",
+                "tailwind-variants": "^3.2.2",
+                "tailwindcss": "^4.3.3",
+                "tinyglobby": "^0.2.17",
+                "ufo": "^1.6.4",
+                "unplugin": "^3.3.0",
+                "unplugin-auto-import": "^21.1.0",
+                "unplugin-vue-components": "^32.1.0",
+                "vaul-vue": "0.4.1",
+                "vue-component-type-helpers": "^3.3.10"
+            },
+            "bin": {
+                "nuxt-ui": "cli/index.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "@vue/compiler-sfc": "^3.5.34",
-                "agents": ">=0.12.4",
-                "h3": ">=1.15.11",
-                "secure-exec": ">=0.2.1",
-                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-                "vue": "^3.5.34",
-                "zod": "^4.1.13"
+                "@inertiajs/vue3": "^2.0.7 || ^3.0.0",
+                "@internationalized/date": "^3.0.0",
+                "@internationalized/number": "^3.0.0",
+                "@nuxt/content": "^3.0.0",
+                "@tiptap/core": "^3",
+                "@tiptap/extension-bubble-menu": "^3",
+                "@tiptap/extension-code": "^3",
+                "@tiptap/extension-collaboration": "^3",
+                "@tiptap/extension-drag-handle": "^3",
+                "@tiptap/extension-drag-handle-vue-3": "^3",
+                "@tiptap/extension-floating-menu": "^3",
+                "@tiptap/extension-horizontal-rule": "^3",
+                "@tiptap/extension-image": "^3",
+                "@tiptap/extension-mention": "^3",
+                "@tiptap/extension-node-range": "^3",
+                "@tiptap/extension-placeholder": "^3",
+                "@tiptap/markdown": "^3",
+                "@tiptap/pm": "^3",
+                "@tiptap/starter-kit": "^3",
+                "@tiptap/suggestion": "^3",
+                "@tiptap/vue-3": "^3",
+                "ai": "^6 || ^7",
+                "joi": "^18.0.0",
+                "superstruct": "^2.0.0",
+                "tailwindcss": "^4.0.0",
+                "typescript": "^5.6.3 || ^6.0.0 || ^7.0.0",
+                "valibot": "^1.0.0",
+                "vue-router": "^4.5.0 || ^5.0.0",
+                "yup": "^1.7.0",
+                "zod": "^3.24.0 || ^4.0.0"
             },
             "peerDependenciesMeta": {
-                "@vue/compiler-sfc": {
+                "@inertiajs/vue3": {
                     "optional": true
                 },
-                "agents": {
+                "@internationalized/date": {
                     "optional": true
                 },
-                "h3": {
-                    "optional": false
+                "@internationalized/number": {
+                    "optional": true
                 },
-                "secure-exec": {
+                "@nuxt/content": {
+                    "optional": true
+                },
+                "ai": {
+                    "optional": true
+                },
+                "joi": {
+                    "optional": true
+                },
+                "superstruct": {
+                    "optional": true
+                },
+                "valibot": {
+                    "optional": true
+                },
+                "vue-router": {
+                    "optional": true
+                },
+                "yup": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/docus/node_modules/@nuxt/ui/node_modules/hookable": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+            "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+            "license": "MIT"
+        },
+        "node_modules/docus/node_modules/@unhead/bundler": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@unhead/bundler/-/bundler-3.4.0.tgz",
+            "integrity": "sha512-RnsCYynvDiUwmZ/U7TkFwFLr6yTRXVFJlZFj3ehi+m6M4f+GWL/O+6BTQzaHdz59zg2UHHejQvwuXvcL7dj0Dw==",
+            "license": "MIT",
+            "dependencies": {
+                "magic-string": "^1.1.0",
+                "oxc-walker": "^1.1.1",
+                "unplugin": "^3.3.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/harlan-zw"
+            },
+            "peerDependencies": {
+                "@unhead/cli": "^3.4.0",
+                "@vitejs/devtools-kit": "^0.4.1",
+                "esbuild": ">=0.17.0",
+                "lightningcss": ">=1.20.0",
+                "oxc-parser": ">=0.98.0",
+                "rolldown": ">=1.0.0",
+                "unhead": "^3.4.0",
+                "vite": ">=6.4.2",
+                "webpack": ">=5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@unhead/cli": {
+                    "optional": true
+                },
+                "@vitejs/devtools-kit": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "oxc-parser": {
+                    "optional": true
+                },
+                "rolldown": {
                     "optional": true
                 },
                 "vite": {
                     "optional": true
                 },
-                "vue": {
+                "webpack": {
                     "optional": true
-                },
-                "zod": {
-                    "optional": false
                 }
             }
         },
-        "node_modules/docus/node_modules/@oxc-parser/binding-android-arm-eabi": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.135.0.tgz",
-            "integrity": "sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==",
-            "cpu": [
-                "arm"
-            ],
+        "node_modules/docus/node_modules/@unhead/vue": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-3.4.0.tgz",
+            "integrity": "sha512-fSnDS9d++bqR4t1z6+zFN7bQB5F0+5nwvE4yHW7BGRfEmssCP4fel0GprooUgoLkzx+FcAWMwVIakyaeErSRBA==",
             "license": "MIT",
+            "dependencies": {
+                "@unhead/bundler": "3.4.0",
+                "hookable": "^6.1.1",
+                "unhead": "3.4.0",
+                "unplugin": "^3.3.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/harlan-zw"
+            },
+            "peerDependencies": {
+                "vite": ">=6.4.2",
+                "vue": ">=3.5.18",
+                "webpack": ">=5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "vite": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/docus/node_modules/@unhead/vue/node_modules/hookable": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+            "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+            "license": "MIT"
+        },
+        "node_modules/docus/node_modules/lightningcss": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
+            }
+        },
+        "node_modules/docus/node_modules/lightningcss-android-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "android"
             ],
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/docus/node_modules/@oxc-parser/binding-android-arm64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.135.0.tgz",
-            "integrity": "sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==",
+        "node_modules/docus/node_modules/lightningcss-darwin-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-darwin-arm64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.135.0.tgz",
-            "integrity": "sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "darwin"
             ],
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/docus/node_modules/@oxc-parser/binding-darwin-x64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.135.0.tgz",
-            "integrity": "sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==",
+        "node_modules/docus/node_modules/lightningcss-darwin-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "darwin"
             ],
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/docus/node_modules/@oxc-parser/binding-freebsd-x64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.135.0.tgz",
-            "integrity": "sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==",
+        "node_modules/docus/node_modules/lightningcss-freebsd-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "freebsd"
             ],
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.135.0.tgz",
-            "integrity": "sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.135.0.tgz",
-            "integrity": "sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.135.0.tgz",
-            "integrity": "sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "libc": [
-                "glibc"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-linux-arm64-musl": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.135.0.tgz",
-            "integrity": "sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.135.0.tgz",
-            "integrity": "sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==",
-            "cpu": [
-                "ppc64"
-            ],
-            "libc": [
-                "glibc"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.135.0.tgz",
-            "integrity": "sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==",
-            "cpu": [
-                "riscv64"
-            ],
-            "libc": [
-                "glibc"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.135.0.tgz",
-            "integrity": "sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.135.0.tgz",
-            "integrity": "sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==",
-            "cpu": [
-                "s390x"
-            ],
-            "libc": [
-                "glibc"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-linux-x64-gnu": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.135.0.tgz",
-            "integrity": "sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==",
-            "cpu": [
-                "x64"
-            ],
-            "libc": [
-                "glibc"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-linux-x64-musl": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.135.0.tgz",
-            "integrity": "sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==",
-            "cpu": [
-                "x64"
-            ],
-            "libc": [
-                "musl"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-openharmony-arm64": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.135.0.tgz",
-            "integrity": "sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/docus/node_modules/@oxc-parser/binding-wasm32-wasi": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.135.0.tgz",
-            "integrity": "sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==",
-            "cpu": [
-                "wasm32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
+                "node": ">= 12.0.0"
             },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/docus/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.135.0.tgz",
-            "integrity": "sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==",
+        "node_modules/docus/node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/docus/node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
             "cpu": [
                 "arm64"
             ],
-            "license": "MIT",
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
-                "win32"
+                "linux"
             ],
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/docus/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.135.0.tgz",
-            "integrity": "sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==",
+        "node_modules/docus/node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
             "cpu": [
-                "ia32"
+                "arm64"
             ],
-            "license": "MIT",
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
-                "win32"
+                "linux"
             ],
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/docus/node_modules/@oxc-parser/binding-win32-x64-msvc": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.135.0.tgz",
-            "integrity": "sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==",
+        "node_modules/docus/node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/docus/node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/docus/node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MPL-2.0",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/docus/node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/docus/node_modules/magic-string": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+            "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
         "node_modules/docus/node_modules/nuxt-og-image": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/nuxt-og-image/-/nuxt-og-image-6.6.0.tgz",
-            "integrity": "sha512-PsnLWVf2D3/pmVvQ/7H17qKtFcKJlH0O611XZhpSx5bEwalNY8tbotmHAqlavhRk5KUvCJBUuCE+QCIW3aBE7w==",
+            "version": "6.7.8",
+            "resolved": "https://registry.npmjs.org/nuxt-og-image/-/nuxt-og-image-6.7.8.tgz",
+            "integrity": "sha512-G7Vm+QNZf5LT85BupX0k8xuA+xjXUB/dY4stLuAIdFmv1CeNbnr5SkFGceRk35FHIK66nIim7wgRU4hGmxzH8Q==",
             "license": "MIT",
             "dependencies": {
-                "@clack/prompts": "^1.5.1",
-                "@nuxt/kit": "^4.4.8",
-                "@unocss/config": "^66.7.0",
-                "@unocss/core": "^66.7.0",
-                "@vue/compiler-sfc": "^3.5.35",
+                "@clack/prompts": "^1.7.0",
+                "@nuxt/kit": "^4.5.2",
+                "@vue/compiler-sfc": "^3.5.41",
                 "chrome-launcher": "^1.2.1",
                 "consola": "^3.4.2",
-                "culori": "^4.0.2",
                 "defu": "^6.1.7",
-                "devalue": "^5.8.1",
-                "exsolve": "^1.0.8",
-                "lightningcss": "^1.32.0",
-                "magic-string": "^0.30.21",
-                "magicast": "^0.5.3",
+                "devalue": "^5.9.0",
+                "exsolve": "^1.1.1",
+                "fnv1a-64": "^0.1.2",
+                "lightningcss": "^1.33.0",
+                "magic-string": "^1.1.0",
+                "magicast": "^0.5.4",
                 "mocked-exports": "^0.1.1",
-                "nuxt-site-config": "^4.0.8",
-                "nuxtseo-shared": "^5.2.6",
-                "nypm": "^0.6.6",
+                "nuxt-site-config": "^4.2.0",
+                "nuxtseo-shared": "^5.3.12",
+                "nypm": "^0.6.9",
+                "object-identity": "^0.2.3",
                 "ofetch": "^1.5.1",
                 "ohash": "^2.0.11",
-                "oxc-parser": "^0.135.0",
-                "oxc-walker": "^1.0.0",
+                "oxc-parser": "^0.143.0",
+                "oxc-walker": "^1.1.1",
                 "pathe": "^2.0.3",
                 "pkg-types": "^2.3.1",
                 "radix3": "^1.1.2",
-                "std-env": "^4.1.0",
-                "strip-literal": "^3.1.0",
-                "tinyexec": "^1.2.4",
-                "tinyglobby": "^0.2.17",
+                "std-env": "^4.2.0",
+                "strip-literal": "^4.0.0",
+                "tinyexec": "^1.3.0",
                 "ufo": "^1.6.4",
-                "ultrahtml": "^1.6.0",
-                "unplugin": "^3.0.0"
+                "ultrahtml": "^1.7.0",
+                "unplugin": "^3.3.0"
             },
             "bin": {
                 "nuxt-og-image": "bin/cli.mjs"
@@ -10973,9 +12167,11 @@
             "peerDependencies": {
                 "@resvg/resvg-js": "^2.6.0",
                 "@resvg/resvg-wasm": "^2.6.0",
-                "@takumi-rs/core": "^1.0.0-beta.3",
-                "@takumi-rs/wasm": "^1.0.0-beta.3",
+                "@takumi-rs/core": "^1.0.0-beta.3 || ^2.0.0",
+                "@takumi-rs/wasm": "^1.0.0-beta.3 || ^2.0.0",
                 "@unhead/vue": "^2.0.5 || ^3.0.0",
+                "@unocss/config": "^66.7.5",
+                "@unocss/core": "^66.7.5",
                 "fontless": "^0.2.0",
                 "nitropack": "^2.13.4",
                 "playwright-core": "^1.50.0",
@@ -10997,6 +12193,12 @@
                     "optional": true
                 },
                 "@takumi-rs/wasm": {
+                    "optional": true
+                },
+                "@unocss/config": {
+                    "optional": true
+                },
+                "@unocss/core": {
                     "optional": true
                 },
                 "fontless": {
@@ -11025,51 +12227,103 @@
                 }
             }
         },
-        "node_modules/docus/node_modules/oxc-parser": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.135.0.tgz",
-            "integrity": "sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==",
+        "node_modules/docus/node_modules/reka-ui": {
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.10.3.tgz",
+            "integrity": "sha512-nJGZbwcha8AcP2wbnjodfzsciTKBqp1mIzepC9Pi2xDI/YK3++ej3vpJOSPyxqrkq1Oorj4K+BdJkbVCV6x6ag==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "^0.135.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "@floating-ui/dom": "^1.6.13",
+                "@floating-ui/vue": "^1.1.6",
+                "@internationalized/date": "^3.5.0",
+                "@internationalized/number": "^3.5.0",
+                "@tanstack/vue-virtual": "^3.12.0",
+                "@vueuse/core": "^14.1.0",
+                "@vueuse/shared": "^14.1.0",
+                "aria-hidden": "^1.2.4",
+                "defu": "^6.1.5",
+                "ohash": "^2.0.11"
             },
             "funding": {
-                "url": "https://github.com/sponsors/Boshen"
+                "type": "github",
+                "url": "https://github.com/sponsors/zernonia"
             },
-            "optionalDependencies": {
-                "@oxc-parser/binding-android-arm-eabi": "0.135.0",
-                "@oxc-parser/binding-android-arm64": "0.135.0",
-                "@oxc-parser/binding-darwin-arm64": "0.135.0",
-                "@oxc-parser/binding-darwin-x64": "0.135.0",
-                "@oxc-parser/binding-freebsd-x64": "0.135.0",
-                "@oxc-parser/binding-linux-arm-gnueabihf": "0.135.0",
-                "@oxc-parser/binding-linux-arm-musleabihf": "0.135.0",
-                "@oxc-parser/binding-linux-arm64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-arm64-musl": "0.135.0",
-                "@oxc-parser/binding-linux-ppc64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-riscv64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-riscv64-musl": "0.135.0",
-                "@oxc-parser/binding-linux-s390x-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-x64-gnu": "0.135.0",
-                "@oxc-parser/binding-linux-x64-musl": "0.135.0",
-                "@oxc-parser/binding-openharmony-arm64": "0.135.0",
-                "@oxc-parser/binding-wasm32-wasi": "0.135.0",
-                "@oxc-parser/binding-win32-arm64-msvc": "0.135.0",
-                "@oxc-parser/binding-win32-ia32-msvc": "0.135.0",
-                "@oxc-parser/binding-win32-x64-msvc": "0.135.0"
+            "peerDependencies": {
+                "vue": ">= 3.4.0"
             }
         },
-        "node_modules/docus/node_modules/oxc-parser/node_modules/@oxc-project/types": {
-            "version": "0.135.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.135.0.tgz",
-            "integrity": "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==",
-            "license": "MIT",
+        "node_modules/docus/node_modules/sharp": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@img/colour": "^1.0.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.7.3"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
             "funding": {
-                "url": "https://github.com/sponsors/Boshen"
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-darwin-arm64": "0.34.5",
+                "@img/sharp-darwin-x64": "0.34.5",
+                "@img/sharp-libvips-darwin-arm64": "1.2.4",
+                "@img/sharp-libvips-darwin-x64": "1.2.4",
+                "@img/sharp-libvips-linux-arm": "1.2.4",
+                "@img/sharp-libvips-linux-arm64": "1.2.4",
+                "@img/sharp-libvips-linux-ppc64": "1.2.4",
+                "@img/sharp-libvips-linux-riscv64": "1.2.4",
+                "@img/sharp-libvips-linux-s390x": "1.2.4",
+                "@img/sharp-libvips-linux-x64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+                "@img/sharp-linux-arm": "0.34.5",
+                "@img/sharp-linux-arm64": "0.34.5",
+                "@img/sharp-linux-ppc64": "0.34.5",
+                "@img/sharp-linux-riscv64": "0.34.5",
+                "@img/sharp-linux-s390x": "0.34.5",
+                "@img/sharp-linux-x64": "0.34.5",
+                "@img/sharp-linuxmusl-arm64": "0.34.5",
+                "@img/sharp-linuxmusl-x64": "0.34.5",
+                "@img/sharp-wasm32": "0.34.5",
+                "@img/sharp-win32-arm64": "0.34.5",
+                "@img/sharp-win32-ia32": "0.34.5",
+                "@img/sharp-win32-x64": "0.34.5"
             }
+        },
+        "node_modules/docus/node_modules/unhead": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/unhead/-/unhead-3.4.0.tgz",
+            "integrity": "sha512-OlgpyYjY+NkFyQCaMihg2uTFbbvyr5lZr6TokS68VdFTXJ5jo4JwFtGR8PwKy/wRpjbQYgKF7ZYO+pbRgxtSmw==",
+            "license": "MIT",
+            "dependencies": {
+                "hookable": "^6.1.1",
+                "unplugin": "^3.3.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/harlan-zw"
+            },
+            "peerDependencies": {
+                "vite": ">=6.4.2"
+            },
+            "peerDependenciesMeta": {
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/docus/node_modules/unhead/node_modules/hookable": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+            "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+            "license": "MIT"
         },
         "node_modules/docus/node_modules/unplugin": {
             "version": "3.3.0",
@@ -11123,15 +12377,6 @@
                 "webpack": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/docus/node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/dom-serializer": {
@@ -11371,6 +12616,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+            "license": "MIT",
+            "dependencies": {
+                "once": "^1.4.0"
             }
         },
         "node_modules/engine.io-client": {
@@ -11847,6 +13101,15 @@
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
+        "node_modules/expand-template": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+            "license": "(MIT OR WTFPL)",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/express": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -11891,9 +13154,9 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "8.6.2",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
-            "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+            "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.3",
@@ -12015,9 +13278,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+            "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
             "funding": [
                 {
                     "type": "github",
@@ -12753,24 +14016,20 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "12.43.0",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
-            "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
+            "version": "13.1.1",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.1.1.tgz",
+            "integrity": "sha512-B/xn2TPS4f61cEBLFjiYlQFnBZUW1YVj/LM+C+N4OP8Rs95VLEI2ot/RlfBg111la/EiyECFaJJi/A3FWA8MUA==",
             "license": "MIT",
             "dependencies": {
-                "motion-dom": "^12.43.0",
-                "motion-utils": "^12.39.0",
+                "motion-dom": "^13.1.1",
+                "motion-utils": "^13.0.0",
                 "tslib": "^2.4.0"
             },
             "peerDependencies": {
-                "@emotion/is-prop-valid": "*",
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
             },
             "peerDependenciesMeta": {
-                "@emotion/is-prop-valid": {
-                    "optional": true
-                },
                 "react": {
                     "optional": true
                 },
@@ -12787,6 +14046,12 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "license": "MIT"
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -12951,6 +14216,12 @@
             "dependencies": {
                 "git-up": "^8.1.0"
             }
+        },
+        "node_modules/github-from-package": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+            "license": "MIT"
         },
         "node_modules/github-slugger": {
             "version": "2.0.0",
@@ -13514,9 +14785,9 @@
             "license": "MIT"
         },
         "node_modules/hono": {
-            "version": "4.13.1",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
-            "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+            "version": "4.13.5",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+            "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
@@ -13877,9 +15148,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-            "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+            "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -14295,9 +15566,9 @@
             }
         },
         "node_modules/jose": {
-            "version": "6.2.8",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
-            "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+            "version": "6.2.10",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+            "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
@@ -14682,9 +15953,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -14704,9 +15972,6 @@
             "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -14728,9 +15993,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -14750,9 +16012,6 @@
             "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -15027,15 +16286,15 @@
             }
         },
         "node_modules/markdown-exit": {
-            "version": "1.0.0-beta.9",
-            "resolved": "https://registry.npmjs.org/markdown-exit/-/markdown-exit-1.0.0-beta.9.tgz",
-            "integrity": "sha512-5tzrMKMF367amyBly131vm6eGuWRL2DjBqWaFmPzPbLyuxP0XOmyyyroOAIXuBAMF/3kZbbfqOxvW/SotqKqbQ==",
+            "version": "1.1.0-beta.2",
+            "resolved": "https://registry.npmjs.org/markdown-exit/-/markdown-exit-1.1.0-beta.2.tgz",
+            "integrity": "sha512-8CzMGVlFZ4DEfnc8KU+4ycUW2SIOuiXqCHD7z51ecVEi/weyc0f2ylQbCm4KoKuVlTZSuMUMnWT0hTyquZ7anQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/linkify-it": "^5.0.0",
                 "@types/mdurl": "^2.0.0",
                 "entities": "^7.0.0",
-                "linkify-it": "^5.0.0",
+                "linkify-it": "^5.0.1",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -16097,6 +17356,12 @@
                 "node": ">= 18"
             }
         },
+        "node_modules/mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "license": "MIT"
+        },
         "node_modules/mlly": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
@@ -16133,30 +17398,30 @@
             "license": "MIT"
         },
         "node_modules/motion-dom": {
-            "version": "12.43.0",
-            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
-            "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
+            "version": "13.1.1",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-13.1.1.tgz",
+            "integrity": "sha512-XSf8VYWSB6G/0IY3rWVbyLcxWXtAVHkN1PQE2agTaCv3u8RGvbwu56TyyR/MNzBqqNavEBTZzErcxI1TxBrjcA==",
             "license": "MIT",
             "dependencies": {
-                "motion-utils": "^12.39.0"
+                "motion-utils": "^13.0.0"
             }
         },
         "node_modules/motion-utils": {
-            "version": "12.39.0",
-            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
-            "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-13.0.0.tgz",
+            "integrity": "sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==",
             "license": "MIT"
         },
         "node_modules/motion-v": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/motion-v/-/motion-v-2.3.0.tgz",
-            "integrity": "sha512-J0CCfXtICCni9RjotDUBOs57xNpYI9yyBSohEOxaRHrmjwOtlw291fhRu/mdgEdSasys96R028YDDOAtWBbRaA==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/motion-v/-/motion-v-2.4.0.tgz",
+            "integrity": "sha512-kRDGMAZk3nvdjEO36Wo6pezSEIStGXGhVFiwo1QkUDsUg8mB5igjYPXyece8wtu2DrHhmFfA6Y1nOz07+5QH4A==",
             "license": "MIT",
             "dependencies": {
-                "framer-motion": "^12.40.0",
+                "framer-motion": "^13.1.0",
                 "hey-listen": "^1.0.8",
-                "motion-dom": "^12.40.0",
-                "motion-utils": "^12.39.0"
+                "motion-dom": "^13.0.0",
+                "motion-utils": "^13.0.0"
             },
             "peerDependencies": {
                 "@vueuse/core": ">=10.0.0",
@@ -16190,6 +17455,12 @@
             "integrity": "sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg==",
             "license": "MIT"
         },
+        "node_modules/napi-build-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+            "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+            "license": "MIT"
+        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -16198,12 +17469,32 @@
             "peer": true
         },
         "node_modules/negotiator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+            "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/negotiator/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/nitropack": {
@@ -16944,6 +18235,18 @@
                 "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
+        "node_modules/node-abi": {
+            "version": "3.96.0",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+            "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/node-emoji": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -17326,9 +18629,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17344,9 +18644,6 @@
             "integrity": "sha512-u9e884ChAVRmIZ1jr/m46S96FoDQnruFjISLi4Y0i6Wu/JUUmIiw7+umLyXILJsPfUuqnN5BJLe23t07+Y6+IA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -17364,9 +18661,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17382,9 +18676,6 @@
             "integrity": "sha512-iuGrxysV4rGUymdKpn7bgZQ6Vix8Bi/6D/rp71HYIzphq6NKrsBhsGOYsSZte+uBFL43tXh7Xr7TM72sGliJNA==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -17402,9 +18693,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17420,9 +18708,6 @@
             "integrity": "sha512-ePxBvvtzISmSsJ0RIj8FNikSCn58i1jtccj7XR4U9Li4iSzhkFyYlnJ51cQTUwkairz8WMTD4SpKoot8RyTnQA==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -17558,9 +18843,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -17576,9 +18858,6 @@
             "integrity": "sha512-dcQhjtcDvtR8BgkUpt03Yz5SzxdzYvTigenIJOEsiSX6G2t6yybEMxGWjp0dOuYGror0BaqcZfTyXR58amCEig==",
             "cpu": [
                 "riscv64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -17652,9 +18931,9 @@
             }
         },
         "node_modules/nuxt-site-config": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/nuxt-site-config/-/nuxt-site-config-4.2.2.tgz",
-            "integrity": "sha512-VF/VDkTANWM21gQGAS6chII7AMyZQlFagZMCYJ6FH5febkWXb6hw1LG1HXvvl68Gc2viA0NI+BtUCIzdlkCB7A==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/nuxt-site-config/-/nuxt-site-config-4.2.3.tgz",
+            "integrity": "sha512-m0CK1Q43T3qtVHSBYeDHav/hp8t/ahhlJGzwdBOQM6WcxeZpF1wcJazoGQAJEFamX1xcRAtA0ZuvvEkwHSMG0w==",
             "license": "MIT",
             "dependencies": {
                 "@nuxt/devalue": "^2.0.2",
@@ -17662,11 +18941,11 @@
                 "consola": "^3.4.2",
                 "defu": "^6.1.7",
                 "h3": "^1.15.11",
-                "nuxt-site-config-kit": "4.2.2",
+                "nuxt-site-config-kit": "4.2.3",
                 "nuxtseo-shared": "^5.3.12",
                 "pathe": "^2.0.3",
                 "pkg-types": "^2.3.1",
-                "site-config-stack": "4.2.2",
+                "site-config-stack": "4.2.3",
                 "ufo": "^1.6.4"
             },
             "funding": {
@@ -17677,13 +18956,13 @@
             }
         },
         "node_modules/nuxt-site-config-kit": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/nuxt-site-config-kit/-/nuxt-site-config-kit-4.2.2.tgz",
-            "integrity": "sha512-bPptsMfi3h7hfvCVff1eTf9/bgG51wKUXp4gTK1yoV4CDlHCrB+UtCo3I/OwaGgy35k9xwfxFCP5GY7LuHomYw==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/nuxt-site-config-kit/-/nuxt-site-config-kit-4.2.3.tgz",
+            "integrity": "sha512-xAU061MrxDlv1CjHjP9+Qg3mAdKxQgO9sFzoy+LblKW+DDLRMGjaEIna/QUk0F0kWzhrf4dSpOVTW8OZv26xVg==",
             "license": "MIT",
             "dependencies": {
                 "@nuxt/kit": "^4.5.2",
-                "site-config-stack": "4.2.2",
+                "site-config-stack": "4.2.3",
                 "std-env": "^4.2.0",
                 "ufo": "^1.6.4"
             },
@@ -18045,9 +19324,9 @@
             }
         },
         "node_modules/nuxtseo-shared": {
-            "version": "5.3.12",
-            "resolved": "https://registry.npmjs.org/nuxtseo-shared/-/nuxtseo-shared-5.3.12.tgz",
-            "integrity": "sha512-fD/zlPWIYQ+tM+i9zGfcsPvOzJDgI+kVM7UPztF360wLN7e1fU7xO4Wbmq6bKhxLTboAuloJwYnv8igc7XOc/w==",
+            "version": "5.3.14",
+            "resolved": "https://registry.npmjs.org/nuxtseo-shared/-/nuxtseo-shared-5.3.14.tgz",
+            "integrity": "sha512-kt3IrUILAD4ElsA5+3uroQUHmDLfQkiYWrdXm4Eb/tSm7L0ug2WQc6Okh9m/KtypCVBfwtChrAVMgSyT/VYP5w==",
             "license": "MIT",
             "dependencies": {
                 "@clack/prompts": "^1.7.0",
@@ -18098,9 +19377,9 @@
             }
         },
         "node_modules/nuxtseo-shared/node_modules/birpc": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.1.0.tgz",
-            "integrity": "sha512-O8L9vALWGqdEe0cG4HJckauw3WeJETlJnDRPUYpgwB7wrU43b/5NGMdVjdVcRo+4ROgd3ih2wha1glDe4HRVgw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-4.2.0.tgz",
+            "integrity": "sha512-KxgKcZPfrtzJDDALHPguGpGJUrzdgpymyiQQgzFjWreHMOpWrnFNVREr5J48x2DBh8ZVioscrV1SBkDipGiX+Q==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
@@ -18181,9 +19460,9 @@
             }
         },
         "node_modules/ohash": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-            "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+            "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
             "license": "MIT"
         },
         "node_modules/on-change": {
@@ -18294,6 +19573,51 @@
             "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
             "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
             "license": "MIT"
+        },
+        "node_modules/oxc-parser": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.143.0.tgz",
+            "integrity": "sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==",
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "^0.143.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            },
+            "optionalDependencies": {
+                "@oxc-parser/binding-android-arm-eabi": "0.143.0",
+                "@oxc-parser/binding-android-arm64": "0.143.0",
+                "@oxc-parser/binding-darwin-arm64": "0.143.0",
+                "@oxc-parser/binding-darwin-x64": "0.143.0",
+                "@oxc-parser/binding-freebsd-x64": "0.143.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.143.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.143.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.143.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.143.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.143.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.143.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.143.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.143.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.143.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.143.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.143.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.143.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.143.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.143.0"
+            }
+        },
+        "node_modules/oxc-parser/node_modules/@oxc-project/types": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+            "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
         },
         "node_modules/oxc-transform": {
             "version": "0.141.0",
@@ -19096,6 +20420,33 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/prebuild-install": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+            "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+            "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+            "license": "MIT",
+            "dependencies": {
+                "detect-libc": "^2.0.0",
+                "expand-template": "^2.0.3",
+                "github-from-package": "0.0.0",
+                "minimist": "^1.2.3",
+                "mkdirp-classic": "^0.5.3",
+                "napi-build-utils": "^2.0.0",
+                "node-abi": "^3.3.0",
+                "pump": "^3.0.0",
+                "rc": "^1.2.7",
+                "simple-get": "^4.0.0",
+                "tar-fs": "^2.0.0",
+                "tunnel-agent": "^0.6.0"
+            },
+            "bin": {
+                "prebuild-install": "bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -19318,6 +20669,16 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/pump": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+            "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+            "license": "MIT",
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -19422,6 +20783,27 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "license": "ISC"
         },
         "node_modules/rc9": {
             "version": "3.0.1",
@@ -20447,9 +21829,9 @@
             "license": "MIT"
         },
         "node_modules/site-config-stack": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/site-config-stack/-/site-config-stack-4.2.2.tgz",
-            "integrity": "sha512-RmXNz4x60G8X7cms/jBJ5xastr+Fh1bXqJTTU9cFiJac0Fi16uVsPmWtvCi9YoKNo6rJO1uvZWTwiSKcWcg2QQ==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/site-config-stack/-/site-config-stack-4.2.3.tgz",
+            "integrity": "sha512-9kJn4YoJvJqbxbE5T1WYl7ibL4SYngcKQ3sP8SfJcgzqtawMMwuBuC2h/DuFSLqVE5ZyMqGtMONm/ax8nSHVrw==",
             "license": "MIT",
             "dependencies": {
                 "ufo": "^1.6.4"
@@ -20745,23 +22127,26 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/strip-literal": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-4.0.0.tgz",
+            "integrity": "sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==",
             "license": "MIT",
             "dependencies": {
-                "js-tokens": "^9.0.1"
+                "js-tokens": "^10.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
             }
-        },
-        "node_modules/strip-literal/node_modules/js-tokens": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-            "license": "MIT"
         },
         "node_modules/structured-clone-es": {
             "version": "2.0.1",
@@ -20917,6 +22302,54 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/tar-fs": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+            "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+            "license": "MIT",
+            "dependencies": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.1.4"
+            }
+        },
+        "node_modules/tar-fs/node_modules/chownr": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+            "license": "ISC"
+        },
+        "node_modules/tar-fs/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/tar-fs/node_modules/tar-stream": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bl": "^4.0.3",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/tar-stream": {
@@ -21130,6 +22563,18 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
         },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -21177,9 +22622,9 @@
             }
         },
         "node_modules/type-is/node_modules/content-type": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -21240,67 +22685,6 @@
             "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
             "license": "MIT"
         },
-        "node_modules/unconfig": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-7.5.0.tgz",
-            "integrity": "sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==",
-            "license": "MIT",
-            "dependencies": {
-                "@quansync/fs": "^1.0.0",
-                "defu": "^6.1.4",
-                "jiti": "^2.6.1",
-                "quansync": "^1.0.0",
-                "unconfig-core": "7.5.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/unconfig-core": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz",
-            "integrity": "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==",
-            "license": "MIT",
-            "dependencies": {
-                "@quansync/fs": "^1.0.0",
-                "quansync": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/unconfig-core/node_modules/quansync": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
-            "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/antfu"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/sxzz"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/unconfig/node_modules/quansync": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
-            "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/antfu"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/sxzz"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/uncrypto": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
@@ -21329,15 +22713,12 @@
             }
         },
         "node_modules/undici": {
-            "version": "5.29.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-            "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
             "license": "MIT",
-            "dependencies": {
-                "@fastify/busboy": "^2.0.0"
-            },
             "engines": {
-                "node": ">=14.0"
+                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
@@ -21489,18 +22870,6 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
-            }
-        },
-        "node_modules/unimport/node_modules/strip-literal": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-4.0.0.tgz",
-            "integrity": "sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==",
-            "license": "MIT",
-            "dependencies": {
-                "js-tokens": "^10.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/unimport/node_modules/unplugin": {
@@ -21674,6 +23043,101 @@
             },
             "engines": {
                 "node": ">=18.12.0"
+            }
+        },
+        "node_modules/unplugin-auto-import": {
+            "version": "21.1.0",
+            "resolved": "https://registry.npmjs.org/unplugin-auto-import/-/unplugin-auto-import-21.1.0.tgz",
+            "integrity": "sha512-EzrSqWIBulEqCuP7idADXH+tVKYrbwKlR5+r/lOWik0o+Ksny1kitmtryHGNSv7puzzORlcIwT/x2JStiszlHA==",
+            "license": "MIT",
+            "dependencies": {
+                "local-pkg": "^1.2.1",
+                "magic-string": "^1.1.0",
+                "picomatch": "^4.0.5",
+                "unimport": "^6.4.0",
+                "unplugin": "^3.3.0",
+                "unplugin-utils": "^0.3.2"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@nuxt/kit": "^4.0.0",
+                "@vueuse/core": "*"
+            },
+            "peerDependenciesMeta": {
+                "@nuxt/kit": {
+                    "optional": true
+                },
+                "@vueuse/core": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/unplugin-auto-import/node_modules/magic-string": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+            "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/unplugin-auto-import/node_modules/unplugin": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+            "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "picomatch": "^4.0.4",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "@farmfe/core": "*",
+                "@rspack/core": "*",
+                "bun-types-no-globals": "*",
+                "esbuild": "*",
+                "rolldown": "*",
+                "rollup": "*",
+                "unloader": "*",
+                "vite": "*",
+                "webpack": "*"
+            },
+            "peerDependenciesMeta": {
+                "@farmfe/core": {
+                    "optional": true
+                },
+                "@rspack/core": {
+                    "optional": true
+                },
+                "bun-types-no-globals": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "rolldown": {
+                    "optional": true
+                },
+                "rollup": {
+                    "optional": true
+                },
+                "unloader": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                },
+                "webpack": {
+                    "optional": true
+                }
             }
         },
         "node_modules/unplugin-utils": {
@@ -22315,6 +23779,448 @@
                 "url": "https://opencollective.com/antfu"
             }
         },
+        "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+            "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+            "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+            "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+            "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+            "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+            "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+            "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+            "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+            "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+            "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+            "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+            "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+            "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+            "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+            "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+            "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+            "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+            "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+            "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+            "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+            "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+            "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+            "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/vite-node/node_modules/cac": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
@@ -22322,6 +24228,49 @@
             "license": "MIT",
             "engines": {
                 "node": ">=20.19.0"
+            }
+        },
+        "node_modules/vite-node/node_modules/esbuild": {
+            "version": "0.28.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+            "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.2",
+                "@esbuild/android-arm": "0.28.2",
+                "@esbuild/android-arm64": "0.28.2",
+                "@esbuild/android-x64": "0.28.2",
+                "@esbuild/darwin-arm64": "0.28.2",
+                "@esbuild/darwin-x64": "0.28.2",
+                "@esbuild/freebsd-arm64": "0.28.2",
+                "@esbuild/freebsd-x64": "0.28.2",
+                "@esbuild/linux-arm": "0.28.2",
+                "@esbuild/linux-arm64": "0.28.2",
+                "@esbuild/linux-ia32": "0.28.2",
+                "@esbuild/linux-loong64": "0.28.2",
+                "@esbuild/linux-mips64el": "0.28.2",
+                "@esbuild/linux-ppc64": "0.28.2",
+                "@esbuild/linux-riscv64": "0.28.2",
+                "@esbuild/linux-s390x": "0.28.2",
+                "@esbuild/linux-x64": "0.28.2",
+                "@esbuild/netbsd-arm64": "0.28.2",
+                "@esbuild/netbsd-x64": "0.28.2",
+                "@esbuild/openbsd-arm64": "0.28.2",
+                "@esbuild/openbsd-x64": "0.28.2",
+                "@esbuild/openharmony-arm64": "0.28.2",
+                "@esbuild/sunos-x64": "0.28.2",
+                "@esbuild/win32-arm64": "0.28.2",
+                "@esbuild/win32-ia32": "0.28.2",
+                "@esbuild/win32-x64": "0.28.2"
             }
         },
         "node_modules/vite-node/node_modules/lightningcss": {
@@ -22460,9 +24409,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -22482,9 +24428,6 @@
             "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -22506,9 +24449,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -22528,9 +24468,6 @@
             "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -23375,9 +25312,9 @@
             }
         },
         "node_modules/vue-component-type-helpers": {
-            "version": "3.3.9",
-            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.9.tgz",
-            "integrity": "sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.11.tgz",
+            "integrity": "sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==",
             "license": "MIT"
         },
         "node_modules/vue-devtools-stub": {
@@ -23781,9 +25718,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+            "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,8 +11,8 @@
         "@nuxt/scripts": "^1.3.3",
         "@nuxt/ui": "^4.10.0",
         "@unhead/vue": "^2.0.17",
-        "better-sqlite3": "^13.0.3",
-        "docus": "latest",
+        "better-sqlite3": "^12.4.1",
+        "docus": "^5.13.0",
         "nuxt": "^4.5.2",
         "typescript": "^5.9.2"
     },


### PR DESCRIPTION
## What broke

Dependabot #22 bumped `better-sqlite3` from 12.4.1 to 13.0.3 inside the grouped npm update. Every published `docus` 5.x, including the current 5.13.0, declares a `better-sqlite3: 12.x` peer range. Dependabot writes lockfiles without enforcing peer ranges; `npm ci` enforces them, so the committed lockfile carries the violation:

```
node_modules/docus          -> 5.12.3   peer: {better-sqlite3: 12.x}
node_modules/better-sqlite3 -> 13.0.3
```

`Deploy Docs` has failed on every push to `2.x` since that merge. Run [33271873450](https://github.com/relaticle/ink/actions/runs/33271873450) (#21) is the same bug, not a second one: it only touched `deploy-docs.yml`, tripped the path filter, and inherited #22's tree.

## Why nothing caught it

`Deploy Docs` triggers on `push` to `2.x` only. #22's checks were `PHP 8.4 / Laravel ^13.0`, `lint`, and `Actions pinned to SHA`. Nothing in this repo has ever run `npm ci` before a merge.

## The fix

The version pins are the repair. The workflow change is the part that stops this recurring.

`Deploy Docs` now splits into a `build` job that runs on `pull_request` as well as `push`, and a `deploy` job that downloads the same artifact and is gated on `github.event_name != 'pull_request'`. The gate builds exactly what ships, so a PR-only workflow cannot drift from the deploy path. Permissions tighten alongside it: `contents: read` at the workflow level, `contents: write` on the deploy job alone.

Three smaller calls ride along:

- `docus: "latest"` becomes `^5.13.0`. `latest` left the lockfile spec at `*`, so dependabot could not track it and a fresh install could cross a major with no commit.
- Runner moves from Node 20 to 22. Node 20 is past end of life, and docus 5.13 pulls `@ai-sdk/gateway`, which declares `engines: node >=22`.
- A dependabot ignore for `better-sqlite3` semver-major, with a comment to drop it when docus widens the peer range. Without it the weekly grouped PR stays red and blocks the other seven packages' updates with it.

Only the two intended direct dependencies move in the regenerated lockfile; the other seven resolve identically.

## Verification

Reproduced the ERESOLVE locally against `origin/2.x`, then ran the CI steps on the fixed tree:

- Node 20.20.2 / npm 10.8.2 (what CI used): `npm ci` clean, `npm run generate` clean, 71 routes prerendered, exit 0
- Node 22.23.1 (what CI uses after this PR): same, exit 0
- Lockfile is platform-portable: linux-x64 `sharp` and `esbuild` variants recorded
- Zizmor goes from 2 medium findings to 1 (the remaining one is the gh-pages checkout, which needs its credentials to push)