### PR TITLE
chore(ci): group security updates and harden workflow checkouts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       default-days: 7
     groups:
       github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
         patterns:
           - "*"
     labels:
@@ -22,6 +27,11 @@ updates:
       default-days: 7
     groups:
       npm:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      npm-security:
+        applies-to: security-updates
         patterns:
           - "*"
     ignore:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -62,6 +62,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout gh-pages
+        # zizmor: ignore[artipacked] the deploy commit below pushes with this credential
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
@@ -69,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.4'


### PR DESCRIPTION
Same cleanup as relaticle/custom-fields#217, applied here.

## Dependabot alerts were off

This repository had vulnerability alerts disabled, so its clean security tab meant "not looking", not "nothing to find". Turning them on surfaced **30 open advisories**, all in `docs/package-lock.json` (brace-expansion, minimatch, vite, sharp, js-yaml, lodash and others). Alerts and Dependabot security updates are now enabled.

## Security update grouping

Each ecosystem gets a `security-updates` group alongside its version-updates group. `applies-to` defaults to version updates, so without this each of those 30 advisories would arrive as its own PR. The existing `better-sqlite3` major-version ignore is untouched.

## Workflows

Clears all 3 code scanning alerts. Verified with `zizmor --no-online-audits`: 3 findings before, 0 after.

- Both checkouts in `tests.yml` never push, so they get `persist-credentials: false`.
- The `gh-pages` checkout in `deploy-docs.yml` is force-pushed at the end of the job, so it keeps its credential and carries an inline ignore saying why.